### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dynamical-catalog"
-version = "0.3.0"
+version = "0.4.0"
 description = "Load dynamical.org weather datasets in one line"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` from `0.3.0` → `0.4.0` ahead of the v0.4.0 PyPI release.

## Test plan
- [x] CI passes
- [x] After merge, run the `Release & Publish` workflow with `0.4.0` — version is already on `main`, so the workflow's commit step no-ops and only the tag + release + PyPI publish are performed.