### PR TITLE
Add test for virtual-chunk icechunk open path

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,9 +9,9 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - run: pip install -e ".[dev]"
-      - run: pytest tests/test_integration.py -v -m slow
+      - run: pytest tests/ -v -m slow

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,8 +9,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
       - run: pip install -e ".[dev]"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate version format
         run: |
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -51,10 +51,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - name: Validate version format
         run: |
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -51,12 +51,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
       - run: pip install -e ".[dev]"
@@ -24,8 +24,8 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - run: pip install -e ".[dev]"
@@ -24,9 +24,9 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
-      - run: pytest tests/ -v
+      - run: pytest tests/ -v -m "slow or not slow"

--- a/tests/test_virtual_open.py
+++ b/tests/test_virtual_open.py
@@ -1,0 +1,169 @@
+"""Build a real virtual icechunk repo and open it through dynamical_catalog.
+
+The repo is created on local disk, but holds one virtual chunk ref pointing at
+real bytes in the public ``noaa-gefs-pds`` S3 bucket. We then:
+
+- patch ``icechunk.s3_storage`` so ``_get_store`` resolves to the local repo
+- patch STAC fetching so ``load_catalog`` returns a collection that matches
+
+This exercises the full path that the catalog uses to serve virtual-chunk-backed
+datasets, including the ``icechunk:virtual_chunk_containers`` authorization step.
+
+Run with: pytest -m slow
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+from unittest.mock import patch
+
+import icechunk
+import pytest
+import xarray as xr
+import zarr
+
+import dynamical_catalog
+import dynamical_catalog._stac as stac
+
+pytestmark = pytest.mark.slow
+
+# Offsets from s3://noaa-gefs-pds/gefs.20260401/00/atmos/pgrb2ap5/gec00.t00z.pgrb2a.0p50.f000.idx:
+#   1:0:d=2026040100:HGT:10 mb:anl:ENS=low-res ctl
+#   2:235395:d=2026040100:TMP:10 mb:anl:ENS=low-res ctl
+# The first grib message spans bytes [0, 235395).
+_GRIB_URL = (
+    "s3://noaa-gefs-pds/gefs.20260401/00/atmos/pgrb2ap5/gec00.t00z.pgrb2a.0p50.f000"
+)
+_GRIB_OFFSET = 0
+_GRIB_LENGTH = 235395
+_CONTAINER_PREFIX = "s3://noaa-gefs-pds/"
+_DATASET_ID = "gefs-virtual-test"
+_COLLECTION_URL = f"https://stac.dynamical.org/{_DATASET_ID}/collection.json"
+
+
+@pytest.fixture(scope="module")
+def virtual_icechunk_repo(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Create a local icechunk repo with one virtual chunk pointing at real S3 bytes."""
+    path = str(tmp_path_factory.mktemp("virtual_icechunk_repo"))
+    storage = icechunk.local_filesystem_storage(path)
+    config = icechunk.RepositoryConfig.default()
+    config.set_virtual_chunk_container(
+        icechunk.VirtualChunkContainer(
+            url_prefix=_CONTAINER_PREFIX,
+            store=icechunk.s3_store(region="us-east-1", anonymous=True),
+        )
+    )
+    authorize = icechunk.containers_credentials(
+        {_CONTAINER_PREFIX: icechunk.s3_anonymous_credentials()}
+    )
+    repo = icechunk.Repository.create(
+        storage, config=config, authorize_virtual_chunk_access=authorize
+    )
+    session = repo.writable_session("main")
+    root = zarr.create_group(store=session.store)
+    root.create_array(
+        name="grib_bytes",
+        shape=(_GRIB_LENGTH,),
+        chunks=(_GRIB_LENGTH,),
+        dtype="uint8",
+        compressors=None,
+        dimension_names=("byte",),
+    )
+    session.store.set_virtual_ref(
+        "grib_bytes/c/0",
+        _GRIB_URL,
+        offset=_GRIB_OFFSET,
+        length=_GRIB_LENGTH,
+    )
+    session.commit("add virtual ref to one grib message")
+    return path
+
+
+@pytest.fixture
+def patched_s3_storage(virtual_icechunk_repo: str) -> Iterator[None]:
+    """Redirect ``icechunk.s3_storage`` to the local virtual repo for this test."""
+
+    def fake_s3_storage(**_kwargs: Any) -> icechunk.Storage:
+        return icechunk.local_filesystem_storage(virtual_icechunk_repo)
+
+    with (
+        patch.object(stac, "_datasets", None),
+        patch(
+            "dynamical_catalog._open.icechunk.s3_storage", side_effect=fake_s3_storage
+        ),
+    ):
+        yield
+
+
+def _mock_stac_fetch(*, with_virtual_containers: bool) -> Callable[[str], Any]:
+    catalog = {
+        "type": "Catalog",
+        "id": "dynamical-org-test",
+        "stac_version": "1.0.0",
+        "links": [
+            {"rel": "self", "href": stac.STAC_CATALOG_URL},
+            {"rel": "root", "href": stac.STAC_CATALOG_URL},
+            {"rel": "child", "href": f"./{_DATASET_ID}/collection.json"},
+        ],
+    }
+    icechunk_asset: dict[str, Any] = {
+        "href": "s3://not-used/not-used/",
+        "type": "application/x-icechunk",
+        "xarray:storage_options": {
+            "anon": True,
+            "client_kwargs": {"region_name": "us-east-1"},
+        },
+    }
+    if with_virtual_containers:
+        icechunk_asset["icechunk:virtual_chunk_containers"] = [
+            {
+                "url_prefix": _CONTAINER_PREFIX,
+                "credentials": {"type": "s3", "anonymous": True},
+            }
+        ]
+    collection = {
+        "type": "Collection",
+        "id": _DATASET_ID,
+        "stac_version": "1.0.0",
+        "title": "GEFS virtual test",
+        "description": "Test dataset backed by a single virtual grib chunk.",
+        "license": "CC-BY-4.0",
+        "assets": {"icechunk": icechunk_asset},
+        "links": [],
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {"interval": [["2026-04-01T00:00:00Z", None]]},
+        },
+    }
+    responses = {stac.STAC_CATALOG_URL: catalog, _COLLECTION_URL: collection}
+
+    def fetch(url: str) -> Any:
+        return responses[url]
+
+    return fetch
+
+
+class TestVirtualOpen:
+    def test_opens_and_reads_virtual_chunk(self, patched_s3_storage: None) -> None:
+        with patch.object(
+            stac,
+            "_fetch_json",
+            side_effect=_mock_stac_fetch(with_virtual_containers=True),
+        ):
+            ds = dynamical_catalog.open(_DATASET_ID)
+            assert isinstance(ds, xr.Dataset)
+            head = ds["grib_bytes"].values[:4]
+            assert bytes(head.tolist()) == b"GRIB"
+
+    def test_missing_virtual_chunk_containers_blocks_read(
+        self, patched_s3_storage: None
+    ) -> None:
+        with patch.object(
+            stac,
+            "_fetch_json",
+            side_effect=_mock_stac_fetch(with_virtual_containers=False),
+        ):
+            ds = dynamical_catalog.open(_DATASET_ID)
+            with pytest.raises(icechunk.IcechunkError, match="virtual chunk"):
+                _ = ds["grib_bytes"].values

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ wheels = [
 
 [[package]]
 name = "dynamical-catalog"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "icechunk" },


### PR DESCRIPTION
Builds a real local icechunk repo with a single virtual chunk ref pointing at bytes in the public noaa-gefs-pds S3 bucket, then patches icechunk.s3_storage and STAC fetching to exercise dynamical_catalog.open end-to-end. Verifies the open path works when icechunk:virtual_chunk_containers is advertised in the STAC, and fails at chunk read time when it isn't.