### PR TITLE
Add and document raised exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Repo guidance for Claude
+
+## Pre-commit checklist
+
+Always run all of the following before committing, and fix any issues
+they surface:
+
+```bash
+uv run --extra dev ruff format .
+uv run --extra dev ruff check .
+uv run --extra dev mypy src
+uv run --extra dev pytest
+```
+
+`ruff format` rewrites files in place — run it before `ruff check` so
+the check sees the formatted source. Don't skip any of these (e.g. with
+`--no-verify`); fix the underlying issue instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynamical-catalog"
-version = "0.5.0"
+version = "0.6.0"
 description = "Load dynamical.org weather datasets in one line"
 readme = "README.md"
 license = "MIT"
@@ -51,6 +51,11 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
+
+[tool.ruff.lint.per-file-ignores]
+# The identify() docstring's first line is part of the user-facing API contract
+# and intentionally contains a long markdown link; allow E501 in __init__.py.
+"src/dynamical_catalog/__init__.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,6 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
-[tool.ruff.lint.per-file-ignores]
-# The identify() docstring's first line is part of the user-facing API contract
-# and intentionally contains a long markdown link; allow E501 in __init__.py.
-"src/dynamical_catalog/__init__.py" = ["E501"]
-
 [tool.mypy]
 python_version = "3.12"
 warn_unused_configs = true

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -41,7 +41,6 @@ def get_store(dataset_id: str) -> Store:
 
     Args:
         dataset_id: Dataset identifier (e.g. ``"noaa-gfs-forecast"``).
-            Underscores are also accepted (e.g. ``"noaa_gfs_forecast"``).
 
     Returns:
         A read-only :class:`zarr.abc.store.Store` backed by the dataset's
@@ -66,7 +65,6 @@ def open(dataset_id: str, **kwargs: Any) -> xr.Dataset:
 
     Args:
         dataset_id: Dataset identifier (e.g. ``"noaa-gfs-forecast"``).
-            Underscores are also accepted (e.g. ``"noaa_gfs_forecast"``).
         **kwargs: Passed through to :func:`xarray.open_zarr`.
 
     Returns:
@@ -105,13 +103,12 @@ def list() -> list[str]:  # type: ignore[valid-type]
 
 def _resolve(dataset_id: str) -> dict[str, Any]:
     datasets = load_catalog()
-    normalized_id = dataset_id.replace("_", "-")
-    if normalized_id not in datasets:
+    if dataset_id not in datasets:
         available = ", ".join(sorted(datasets.keys()))
         raise UnknownDatasetError(
             f"Unknown dataset {dataset_id!r}. Available: {available}"
         )
-    return datasets[normalized_id]
+    return datasets[dataset_id]
 
 
 __all__ = [

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any
 
@@ -102,12 +103,24 @@ def list() -> list[str]:  # type: ignore[valid-type]
 
 def _resolve(dataset_id: str) -> dict[str, Any]:
     datasets = load_catalog()
-    if dataset_id not in datasets:
-        available = ", ".join(sorted(datasets.keys()))
-        raise UnknownDatasetError(
-            f"Unknown dataset {dataset_id!r}. Available: {available}"
-        )
-    return datasets[dataset_id]
+    if dataset_id in datasets:
+        return datasets[dataset_id]
+    # Underscore form is deprecated but still accepted when it resolves to a
+    # real id. Only warn on resolved hits — a typo with underscores should
+    # surface as UnknownDatasetError, not a deprecation notice.
+    if "_" in dataset_id:
+        normalized_id = dataset_id.replace("_", "-")
+        if normalized_id in datasets:
+            warnings.warn(
+                f"Underscores in dataset ids are deprecated and will be "
+                f"removed in 1.0; use {normalized_id!r} instead of "
+                f"{dataset_id!r}.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return datasets[normalized_id]
+    available = ", ".join(sorted(datasets.keys()))
+    raise UnknownDatasetError(f"Unknown dataset {dataset_id!r}. Available: {available}")
 
 
 __all__ = [

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -88,8 +88,7 @@ def list() -> list[str]:  # type: ignore[valid-type]
     """List available dataset IDs, sorted alphabetically.
 
     On the first call (per process) this fetches the STAC catalog from
-    dynamical.org; subsequent calls reuse the in-process cache. Returns
-    an empty list if the catalog has no datasets.
+    dynamical.org; subsequent calls reuse the in-process cache.
 
     Returns:
         Sorted list of dataset IDs.

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -1,5 +1,9 @@
 """dynamical_catalog - Load dynamical.org weather datasets in one line."""
 
+# ruff: noqa: E501
+# The identify() docstring's first line is part of the user-facing API contract
+# and intentionally contains a long markdown link.
+
 from __future__ import annotations
 
 from importlib.metadata import version

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -24,11 +24,7 @@ __version__ = version("dynamical-catalog")
 def identify(identifier: str | None) -> None:
     """Set a user identifier to help dynamical.org improve the catalog.
 
-    The identifier (typically an email) is included in the User-Agent header.
-
-    The User-Agent format is ``dynamical-catalog/<version> (<identifier>)``.
-    Passing an empty string or ``None`` disables identification — the
-    parenthesized identifier is omitted from subsequent requests.
+    Passing an empty string or ``None`` disables identification.
 
     Args:
         identifier: Email or company name (e.g. ``"you@example.com"``), or

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -26,7 +26,7 @@ __version__ = version("dynamical-catalog")
 
 
 def identify(identifier: str | None) -> None:
-    """Set a user identifier to help [dynamical.org](http://dynamical.org) improve our catalog.
+    """Set a user identifier to help [dynamical.org](http://dynamical.org) improve the catalog.
 
     The identifier (typically an email) is included in the User-Agent header.
 

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -10,18 +10,29 @@ if TYPE_CHECKING:
     from zarr.abc.store import Store
 
 from dynamical_catalog._stac import clear_cache, load_catalog, set_identifier
+from dynamical_catalog.exceptions import (
+    CatalogFetchError,
+    DatasetOpenError,
+    DynamicalCatalogError,
+    InvalidCatalogError,
+    UnknownDatasetError,
+)
 
 __version__ = version("dynamical-catalog")
 
 
-def identify(identifier: str) -> None:
-    """Set your identity for STAC catalog requests.
+def identify(identifier: str | None) -> None:
+    """Set a user identifier to help [dynamical.org](http://dynamical.org) improve our catalog.
 
-    The identifier (typically an email or company name) is included in
-    the User-Agent header: ``dynamical-catalog/0.1.0 (identifier)``.
+    The identifier (typically an email) is included in the User-Agent header.
+
+    The User-Agent format is ``dynamical-catalog/<version> (<identifier>)``.
+    Passing an empty string or ``None`` disables identification — the
+    parenthesized identifier is omitted from subsequent requests.
 
     Args:
-        identifier: Email or company name, e.g. "marshall@dynamical.org".
+        identifier: Email or company name (e.g. ``"you@example.com"``), or
+            ``None`` / ``""`` to disable identification.
     """
     set_identifier(identifier)
 
@@ -29,12 +40,22 @@ def identify(identifier: str) -> None:
 def get_store(dataset_id: str) -> Store:
     """Get a zarr Store for a dynamical.org dataset's icechunk repository.
 
+    On the first call (per process) this fetches the STAC catalog from
+    dynamical.org; subsequent calls reuse the in-process cache.
+
     Args:
-        dataset_id: Dataset identifier (e.g. "noaa-gfs-forecast").
-            Underscores are also accepted (e.g. "noaa_gfs_forecast").
+        dataset_id: Dataset identifier (e.g. ``"noaa-gfs-forecast"``).
+            Underscores are also accepted (e.g. ``"noaa_gfs_forecast"``).
 
     Returns:
-        zarr.abc.Store
+        A read-only :class:`zarr.abc.store.Store` backed by the dataset's
+        icechunk repository.
+
+    Raises:
+        UnknownDatasetError: ``dataset_id`` is not in the catalog.
+        CatalogFetchError: Fetching the STAC catalog failed.
+        InvalidCatalogError: The catalog response was reachable but malformed.
+        DatasetOpenError: Opening the icechunk repository failed.
     """
     from dynamical_catalog._open import _get_store
 
@@ -42,15 +63,27 @@ def get_store(dataset_id: str) -> Store:
 
 
 def open(dataset_id: str, **kwargs: Any) -> xr.Dataset:
-    """Open a dynamical.org dataset by ID.
+    """Open a dynamical.org dataset by ID as an :class:`xarray.Dataset`.
+
+    On the first call (per process) this fetches the STAC catalog from
+    dynamical.org; subsequent calls reuse the in-process cache.
 
     Args:
-        dataset_id: Dataset identifier (e.g. "noaa-gfs-forecast").
-            Underscores are also accepted (e.g. "noaa_gfs_forecast").
-        **kwargs: Passed through to xr.open_zarr().
+        dataset_id: Dataset identifier (e.g. ``"noaa-gfs-forecast"``).
+            Underscores are also accepted (e.g. ``"noaa_gfs_forecast"``).
+        **kwargs: Passed through to :func:`xarray.open_zarr`.
 
     Returns:
-        xarray.Dataset
+        The dataset as an :class:`xarray.Dataset`.
+
+    Raises:
+        UnknownDatasetError: ``dataset_id`` is not in the catalog.
+        CatalogFetchError: Fetching the STAC catalog failed.
+        InvalidCatalogError: The catalog response was reachable but malformed.
+        DatasetOpenError: Opening the icechunk repository or zarr store
+            failed. This covers eager errors at open time only; errors
+            raised later when reading data lazily from the returned
+            dataset are not wrapped.
     """
     from dynamical_catalog._open import _open_dataset
 
@@ -58,7 +91,19 @@ def open(dataset_id: str, **kwargs: Any) -> xr.Dataset:
 
 
 def list() -> list[str]:  # type: ignore[valid-type]
-    """List available dataset IDs."""
+    """List available dataset IDs, sorted alphabetically.
+
+    On the first call (per process) this fetches the STAC catalog from
+    dynamical.org; subsequent calls reuse the in-process cache. Returns
+    an empty list if the catalog has no datasets.
+
+    Returns:
+        Sorted list of dataset IDs (hyphenated form).
+
+    Raises:
+        CatalogFetchError: Fetching the STAC catalog failed.
+        InvalidCatalogError: The catalog response was reachable but malformed.
+    """
     return sorted(load_catalog().keys())
 
 
@@ -67,11 +112,18 @@ def _resolve(dataset_id: str) -> dict[str, Any]:
     normalized_id = dataset_id.replace("_", "-")
     if normalized_id not in datasets:
         available = ", ".join(sorted(datasets.keys()))
-        raise ValueError(f"Unknown dataset {dataset_id!r}. Available: {available}")
+        raise UnknownDatasetError(
+            f"Unknown dataset {dataset_id!r}. Available: {available}"
+        )
     return datasets[normalized_id]
 
 
 __all__ = [
+    "CatalogFetchError",
+    "DatasetOpenError",
+    "DynamicalCatalogError",
+    "InvalidCatalogError",
+    "UnknownDatasetError",
     "__version__",
     "clear_cache",
     "get_store",

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -92,7 +92,7 @@ def list() -> list[str]:  # type: ignore[valid-type]
     an empty list if the catalog has no datasets.
 
     Returns:
-        Sorted list of dataset IDs (hyphenated form).
+        Sorted list of dataset IDs.
 
     Raises:
         CatalogFetchError: Fetching the STAC catalog failed.

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -1,9 +1,5 @@
 """dynamical_catalog - Load dynamical.org weather datasets in one line."""
 
-# ruff: noqa: E501
-# The identify() docstring's first line is part of the user-facing API contract
-# and intentionally contains a long markdown link.
-
 from __future__ import annotations
 
 from importlib.metadata import version
@@ -26,7 +22,7 @@ __version__ = version("dynamical-catalog")
 
 
 def identify(identifier: str | None) -> None:
-    """Set a user identifier to help [dynamical.org](http://dynamical.org) improve the catalog.
+    """Set a user identifier to help dynamical.org improve the catalog.
 
     The identifier (typically an email) is included in the User-Agent header.
 

--- a/src/dynamical_catalog/_open.py
+++ b/src/dynamical_catalog/_open.py
@@ -48,6 +48,5 @@ def _open_dataset(dataset_data: dict[str, Any], **kwargs: Any) -> xr.Dataset:
         return xr.open_zarr(store, **kwargs)
     except Exception as e:
         raise DatasetOpenError(
-            f"Failed to open dataset {dataset_data.get('id')!r} as xarray "
-            f"Dataset: {e}"
+            f"Failed to open dataset {dataset_data.get('id')!r} as xarray Dataset: {e}"
         ) from e

--- a/src/dynamical_catalog/_open.py
+++ b/src/dynamical_catalog/_open.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any
 import icechunk
 import xarray as xr
 
+from dynamical_catalog.exceptions import DatasetOpenError
+
 if TYPE_CHECKING:
     from zarr.abc.store import Store
 
@@ -25,12 +27,27 @@ def _get_store(dataset_data: dict[str, Any]) -> Store:
         if prefixes
         else None
     )
-    repo = icechunk.Repository.open(storage, authorize_virtual_chunk_access=authorize)
-    session = repo.readonly_session("main")
-    return session.store
+    try:
+        repo = icechunk.Repository.open(
+            storage, authorize_virtual_chunk_access=authorize
+        )
+        session = repo.readonly_session("main")
+        return session.store
+    except icechunk.IcechunkError as e:
+        raise DatasetOpenError(
+            f"Failed to open icechunk repository for dataset "
+            f"{dataset_data.get('id')!r}: {e}"
+        ) from e
 
 
 def _open_dataset(dataset_data: dict[str, Any], **kwargs: Any) -> xr.Dataset:
     # icechunk manages its own metadata; zarr's consolidated metadata doesn't apply.
     kwargs.setdefault("consolidated", False)
-    return xr.open_zarr(_get_store(dataset_data), **kwargs)
+    store = _get_store(dataset_data)
+    try:
+        return xr.open_zarr(store, **kwargs)
+    except Exception as e:
+        raise DatasetOpenError(
+            f"Failed to open dataset {dataset_data.get('id')!r} as xarray "
+            f"Dataset: {e}"
+        ) from e

--- a/src/dynamical_catalog/_open.py
+++ b/src/dynamical_catalog/_open.py
@@ -27,6 +27,7 @@ def _get_store(dataset_data: dict[str, Any]) -> Store:
         if prefixes
         else None
     )
+    dataset_id = dataset_data.get("id")
     try:
         repo = icechunk.Repository.open(
             storage, authorize_virtual_chunk_access=authorize
@@ -35,18 +36,20 @@ def _get_store(dataset_data: dict[str, Any]) -> Store:
         return session.store
     except icechunk.IcechunkError as e:
         raise DatasetOpenError(
-            f"Failed to open icechunk repository for dataset "
-            f"{dataset_data.get('id')!r}: {e}"
+            f"Failed to open icechunk repository for dataset {dataset_id!r}: {e}",
+            dataset_id=dataset_id,
         ) from e
 
 
 def _open_dataset(dataset_data: dict[str, Any], **kwargs: Any) -> xr.Dataset:
     # icechunk manages its own metadata; zarr's consolidated metadata doesn't apply.
     kwargs.setdefault("consolidated", False)
+    dataset_id = dataset_data.get("id")
     store = _get_store(dataset_data)
     try:
         return xr.open_zarr(store, **kwargs)
     except Exception as e:
         raise DatasetOpenError(
-            f"Failed to open dataset {dataset_data.get('id')!r} as xarray Dataset: {e}"
+            f"Failed to open dataset {dataset_id!r} as xarray Dataset: {e}",
+            dataset_id=dataset_id,
         ) from e

--- a/src/dynamical_catalog/_stac.py
+++ b/src/dynamical_catalog/_stac.py
@@ -10,6 +10,11 @@ import urllib.request
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
+from dynamical_catalog.exceptions import (
+    CatalogFetchError,
+    InvalidCatalogError,
+)
+
 STAC_CATALOG_URL = "https://stac.dynamical.org/catalog.json"
 
 _TIMEOUT_SECONDS = 10
@@ -19,9 +24,14 @@ _datasets: dict[str, dict[str, Any]] | None = None
 _identifier: str | None = None
 
 
-def set_identifier(identifier: str) -> None:
+def set_identifier(identifier: str | None) -> None:
+    """Set the identifier sent in the User-Agent header.
+
+    Passing ``""`` or ``None`` disables identification. Empty strings are
+    normalized to ``None`` so reads of ``_identifier`` are predictable.
+    """
     global _identifier
-    _identifier = identifier
+    _identifier = identifier or None
 
 
 def _user_agent() -> str:
@@ -40,27 +50,40 @@ def _fetch_json(url: str) -> Any:
         try:
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
                 return json.loads(resp.read())
-        except urllib.error.URLError as e:
+        except (urllib.error.URLError, json.JSONDecodeError) as e:
             last_error = e
             if attempt < _MAX_ATTEMPTS - 1:
                 time.sleep(_RETRY_BACKOFF_SECONDS)
-    raise RuntimeError(
-        f"Failed to fetch dynamical.org STAC catalog from {url}: {last_error}"
+    raise CatalogFetchError(
+        f"Failed to fetch dynamical.org STAC catalog from {url}: {last_error}",
+        url=url,
+        attempts=_MAX_ATTEMPTS,
     ) from last_error
 
 
 def _parse_icechunk_asset(collection_id: str, asset: dict[str, Any]) -> dict[str, str]:
-    parsed = urlparse(asset["href"])
-    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.lstrip("/"):
-        raise ValueError(
-            f"STAC Collection {collection_id} icechunk asset href is not an s3:// URL "
-            f"with bucket and prefix: {asset['href']!r}"
+    href = asset["href"]
+    parsed = urlparse(href)
+    if parsed.scheme != "s3":
+        raise InvalidCatalogError(
+            f"STAC Collection {collection_id} icechunk asset href scheme is not "
+            f"s3: {href!r}"
+        )
+    if not parsed.netloc:
+        raise InvalidCatalogError(
+            f"STAC Collection {collection_id} icechunk asset href is missing "
+            f"a bucket: {href!r}"
+        )
+    if not parsed.path.lstrip("/"):
+        raise InvalidCatalogError(
+            f"STAC Collection {collection_id} icechunk asset href is missing "
+            f"a prefix: {href!r}"
         )
     storage_options = asset.get("xarray:storage_options", {})
     client_kwargs = storage_options.get("client_kwargs", {})
     region = client_kwargs.get("region_name")
     if not region:
-        raise ValueError(
+        raise InvalidCatalogError(
             f"STAC Collection {collection_id} icechunk asset is missing "
             f"xarray:storage_options.client_kwargs.region_name"
         )
@@ -80,17 +103,24 @@ def _parse_virtual_chunk_containers(
     advertise static credentials.
     """
     containers = asset.get("icechunk:virtual_chunk_containers", [])
+    if containers is None:
+        containers = []
+    if not isinstance(containers, list):
+        raise InvalidCatalogError(
+            f"STAC Collection {collection_id} icechunk:virtual_chunk_containers "
+            f"must be a list, got {type(containers).__name__}: {containers!r}"
+        )
     prefixes: list[str] = []
     for entry in containers:
         prefix = entry.get("url_prefix")
         if not isinstance(prefix, str) or not prefix.startswith("s3://"):
-            raise ValueError(
+            raise InvalidCatalogError(
                 f"STAC Collection {collection_id} virtual chunk container "
                 f"url_prefix must be an s3:// string: {prefix!r}"
             )
         credentials = entry.get("credentials") or {}
         if credentials.get("type") != "s3" or not credentials.get("anonymous"):
-            raise ValueError(
+            raise InvalidCatalogError(
                 f"STAC Collection {collection_id} virtual chunk container "
                 f"{prefix!r} must use {{type: 's3', anonymous: true}} credentials"
             )
@@ -100,11 +130,17 @@ def _parse_virtual_chunk_containers(
 
 def _parse_collection(collection: dict[str, Any]) -> dict[str, Any]:
     """Extract the dataset config we need from a STAC Collection."""
+    if "id" not in collection:
+        raise InvalidCatalogError("STAC Collection response is missing 'id'")
     collection_id = collection["id"]
-    assets = collection.get("assets", {})
+    if "assets" not in collection:
+        raise InvalidCatalogError(
+            f"STAC Collection {collection_id} is missing 'assets'"
+        )
+    assets = collection["assets"]
     icechunk_asset = assets.get("icechunk")
     if icechunk_asset is None:
-        raise ValueError(
+        raise InvalidCatalogError(
             f"STAC Collection {collection_id} is missing an 'icechunk' asset"
         )
 
@@ -124,22 +160,53 @@ def load_catalog() -> dict[str, dict[str, Any]]:
 
     Results are cached in-process after the first call.
     Child collections are fetched in parallel for faster startup.
+    An empty catalog (no child links) returns an empty dict.
     """
     global _datasets
     if _datasets is not None:
         return _datasets
 
     catalog = _fetch_json(STAC_CATALOG_URL)
+    if "links" not in catalog:
+        raise InvalidCatalogError("STAC catalog response is missing 'links'")
     child_links = [link for link in catalog["links"] if link["rel"] == "child"]
     urls = [urljoin(STAC_CATALOG_URL, link["href"]) for link in child_links]
 
+    collections: list[dict[str, Any]] = [{} for _ in urls]
+    failures: list[tuple[str, Exception]] = []
     with concurrent.futures.ThreadPoolExecutor() as pool:
-        collections = pool.map(_fetch_json, urls)
+        future_to_index = {
+            pool.submit(_fetch_json, url): i for i, url in enumerate(urls)
+        }
+        for future in concurrent.futures.as_completed(future_to_index):
+            index = future_to_index[future]
+            try:
+                collections[index] = future.result()
+            except Exception as e:
+                failures.append((urls[index], e))
+
+    if failures:
+        failed_urls = [url for url, _ in failures]
+        joined = ", ".join(failed_urls)
+        first_error = failures[0][1]
+        raise CatalogFetchError(
+            f"Failed to fetch {len(failures)} STAC collection(s): {joined}",
+            url=joined,
+            attempts=_MAX_ATTEMPTS,
+        ) from first_error
 
     datasets: dict[str, dict[str, Any]] = {}
-    for collection in collections:
+    seen_urls: dict[str, str] = {}
+    for url, collection in zip(urls, collections, strict=True):
         parsed = _parse_collection(collection)
-        datasets[parsed["id"]] = parsed
+        dataset_id = parsed["id"]
+        if dataset_id in datasets:
+            raise InvalidCatalogError(
+                f"STAC catalog contains duplicate dataset id {dataset_id!r}: "
+                f"{seen_urls[dataset_id]} and {url}"
+            )
+        datasets[dataset_id] = parsed
+        seen_urls[dataset_id] = url
 
     _datasets = datasets
     return _datasets

--- a/src/dynamical_catalog/_stac.py
+++ b/src/dynamical_catalog/_stac.py
@@ -69,7 +69,7 @@ def _fetch_json(url: str) -> Any:
                 raise CatalogFetchError(
                     f"Failed to fetch dynamical.org STAC catalog from {url}: "
                     f"HTTP {e.code} {e.reason}",
-                    url=url,
+                    urls=(url,),
                     attempts=attempt + 1,
                 ) from e
             last_error = e
@@ -88,12 +88,12 @@ def _fetch_json(url: str) -> Any:
             raise CatalogFetchError(
                 f"Failed to fetch dynamical.org STAC catalog from {url}: "
                 f"response was not valid JSON: {e}",
-                url=url,
+                urls=(url,),
                 attempts=attempt + 1,
             ) from e
     raise CatalogFetchError(
         f"Failed to fetch dynamical.org STAC catalog from {url}: {last_error}",
-        url=url,
+        urls=(url,),
         attempts=_MAX_ATTEMPTS,
     ) from last_error
 
@@ -223,12 +223,11 @@ def load_catalog() -> dict[str, dict[str, Any]]:
                 failures.append((urls[index], e))
 
     if failures:
-        failed_urls = [url for url, _ in failures]
-        joined = ", ".join(failed_urls)
+        failed_urls = tuple(url for url, _ in failures)
         first_error = failures[0][1]
         raise CatalogFetchError(
-            f"Failed to fetch {len(failures)} STAC collection(s): {joined}",
-            url=joined,
+            f"Failed to fetch {len(failures)} STAC collection(s): {failed_urls}",
+            urls=failed_urls,
             attempts=_MAX_ATTEMPTS,
         ) from first_error
 

--- a/src/dynamical_catalog/_stac.py
+++ b/src/dynamical_catalog/_stac.py
@@ -49,11 +49,22 @@ def _fetch_json(url: str) -> Any:
     for attempt in range(_MAX_ATTEMPTS):
         try:
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
-                return json.loads(resp.read())
-        except (urllib.error.URLError, json.JSONDecodeError) as e:
+                body = resp.read()
+        except urllib.error.URLError as e:
             last_error = e
             if attempt < _MAX_ATTEMPTS - 1:
                 time.sleep(_RETRY_BACKOFF_SECONDS)
+            continue
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as e:
+            # Malformed JSON won't change between attempts; fail fast.
+            raise CatalogFetchError(
+                f"Failed to fetch dynamical.org STAC catalog from {url}: "
+                f"response was not valid JSON: {e}",
+                url=url,
+                attempts=attempt + 1,
+            ) from e
     raise CatalogFetchError(
         f"Failed to fetch dynamical.org STAC catalog from {url}: {last_error}",
         url=url,

--- a/src/dynamical_catalog/_stac.py
+++ b/src/dynamical_catalog/_stac.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import http.client
 import json
 import time
 import urllib.error
@@ -43,6 +44,17 @@ def _user_agent() -> str:
     return ua
 
 
+# Mid-stream / connection-level errors that can leak past urllib.error.URLError
+# when the failure happens after urlopen() returns. Retrying is worth it because
+# the next attempt opens a fresh connection.
+_RETRIABLE_TRANSIENT_ERRORS = (
+    urllib.error.URLError,
+    TimeoutError,
+    http.client.RemoteDisconnected,
+    http.client.IncompleteRead,
+)
+
+
 def _fetch_json(url: str) -> Any:
     req = urllib.request.Request(url, headers={"User-Agent": _user_agent()})
     last_error: Exception | None = None
@@ -50,7 +62,21 @@ def _fetch_json(url: str) -> Any:
         try:
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
                 body = resp.read()
-        except urllib.error.URLError as e:
+        except urllib.error.HTTPError as e:
+            # 4xx (except 429 Too Many Requests) won't change between attempts;
+            # fail fast.
+            if 400 <= e.code < 500 and e.code != 429:
+                raise CatalogFetchError(
+                    f"Failed to fetch dynamical.org STAC catalog from {url}: "
+                    f"HTTP {e.code} {e.reason}",
+                    url=url,
+                    attempts=attempt + 1,
+                ) from e
+            last_error = e
+            if attempt < _MAX_ATTEMPTS - 1:
+                time.sleep(_RETRY_BACKOFF_SECONDS)
+            continue
+        except _RETRIABLE_TRANSIENT_ERRORS as e:
             last_error = e
             if attempt < _MAX_ATTEMPTS - 1:
                 time.sleep(_RETRY_BACKOFF_SECONDS)

--- a/src/dynamical_catalog/_stac.py
+++ b/src/dynamical_catalog/_stac.py
@@ -197,7 +197,6 @@ def load_catalog() -> dict[str, dict[str, Any]]:
 
     Results are cached in-process after the first call.
     Child collections are fetched in parallel for faster startup.
-    An empty catalog (no child links) returns an empty dict.
     """
     global _datasets
     if _datasets is not None:

--- a/src/dynamical_catalog/exceptions.py
+++ b/src/dynamical_catalog/exceptions.py
@@ -1,0 +1,64 @@
+"""Exception hierarchy raised by ``dynamical_catalog``.
+
+All exceptions raised by this package inherit from
+:class:`DynamicalCatalogError`, so callers can write a single
+``except DynamicalCatalogError`` to catch anything we raise.
+"""
+
+from __future__ import annotations
+
+
+class DynamicalCatalogError(Exception):
+    """Base class for all exceptions raised by ``dynamical_catalog``."""
+
+
+class UnknownDatasetError(DynamicalCatalogError, ValueError):
+    """Raised when a user-supplied ``dataset_id`` is not in the catalog.
+
+    Multi-inherits from :class:`ValueError` so callers that previously
+    caught ``ValueError`` keep working.
+    """
+
+
+class CatalogFetchError(DynamicalCatalogError):
+    """Raised when fetching the STAC catalog fails.
+
+    Covers network errors, HTTP errors, and malformed JSON responses.
+
+    Attributes:
+        url: The URL (or list of URLs, joined) that failed.
+        attempts: Number of attempts made before giving up.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str,
+        attempts: int,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.attempts = attempts
+
+
+class InvalidCatalogError(DynamicalCatalogError):
+    """Raised when the STAC catalog response is reachable but malformed."""
+
+
+class DatasetOpenError(DynamicalCatalogError):
+    """Raised when opening the icechunk repo or zarr/xarray dataset fails.
+
+    Covers eager errors at open time (e.g. bucket not found, virtual chunk
+    authorization). Lazy errors raised when the caller later reads data
+    from the returned :class:`xarray.Dataset` are not wrapped.
+    """
+
+
+__all__ = [
+    "CatalogFetchError",
+    "DatasetOpenError",
+    "DynamicalCatalogError",
+    "InvalidCatalogError",
+    "UnknownDatasetError",
+]

--- a/src/dynamical_catalog/exceptions.py
+++ b/src/dynamical_catalog/exceptions.py
@@ -26,7 +26,9 @@ class CatalogFetchError(DynamicalCatalogError):
     Covers network errors, HTTP errors, and malformed JSON responses.
 
     Attributes:
-        url: The URL (or list of URLs, joined) that failed.
+        urls: Tuple of URLs that failed. A single-URL fetch failure
+            stores a one-element tuple; aggregated child-collection
+            failures store every failed URL.
         attempts: Number of attempts made before giving up.
     """
 
@@ -34,11 +36,11 @@ class CatalogFetchError(DynamicalCatalogError):
         self,
         message: str,
         *,
-        url: str,
+        urls: tuple[str, ...],
         attempts: int,
     ) -> None:
         super().__init__(message)
-        self.url = url
+        self.urls = urls
         self.attempts = attempts
 
 
@@ -52,7 +54,19 @@ class DatasetOpenError(DynamicalCatalogError):
     Covers eager errors at open time (e.g. bucket not found, virtual chunk
     authorization). Lazy errors raised when the caller later reads data
     from the returned :class:`xarray.Dataset` are not wrapped.
+
+    Attributes:
+        dataset_id: The dataset id that failed to open, if known.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        dataset_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.dataset_id = dataset_id
 
 
 __all__ = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 import dynamical_catalog
@@ -13,6 +15,24 @@ class TestOpen:
         mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
         dynamical_catalog.open("noaa-gfs-forecast")
         mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
+
+    def test_open_underscore_id_resolves_with_deprecation_warning(
+        self, populated_catalog, mocker
+    ):
+        mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
+        with pytest.warns(DeprecationWarning, match="Underscores in dataset ids"):
+            dynamical_catalog.open("noaa_gfs_forecast")
+        mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
+
+    def test_open_underscore_unknown_id_raises_without_deprecation_warning(
+        self, populated_catalog
+    ):
+        # An underscore id that doesn't resolve should surface as
+        # UnknownDatasetError, not a misleading deprecation notice.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(UnknownDatasetError):
+                dynamical_catalog.open("nonexistent_dataset")
 
     def test_open_passes_kwargs(self, populated_catalog, mocker):
         mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
@@ -64,6 +84,14 @@ class TestGetStore:
     def test_get_store_by_dataset_id(self, populated_catalog, mocker):
         mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
         dynamical_catalog.get_store("noaa-gfs-forecast")
+        mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
+
+    def test_get_store_underscore_id_resolves_with_deprecation_warning(
+        self, populated_catalog, mocker
+    ):
+        mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
+        with pytest.warns(DeprecationWarning, match="Underscores in dataset ids"):
+            dynamical_catalog.get_store("noaa_gfs_forecast")
         mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
 
     def test_get_store_triggers_catalog_fetch_on_cold_cache(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,10 @@ import pytest
 
 import dynamical_catalog
 import dynamical_catalog._stac as stac
+from dynamical_catalog.exceptions import (
+    DynamicalCatalogError,
+    UnknownDatasetError,
+)
 
 
 class TestOpen:
@@ -22,12 +26,22 @@ class TestOpen:
             populated_catalog["noaa-gfs-forecast"], chunks={"time": 1}
         )
 
-    def test_open_unknown_raises_valueerror(self, populated_catalog):
+    def test_open_unknown_raises_unknown_dataset_error(self, populated_catalog):
+        with pytest.raises(UnknownDatasetError, match="Unknown dataset"):
+            dynamical_catalog.open("nonexistent")
+
+    def test_open_unknown_is_value_error_for_compat(self, populated_catalog):
+        # UnknownDatasetError multi-inherits from ValueError so callers that
+        # caught ValueError before the typed-exception migration keep working.
         with pytest.raises(ValueError, match="Unknown dataset"):
             dynamical_catalog.open("nonexistent")
 
+    def test_open_unknown_is_dynamical_catalog_error(self, populated_catalog):
+        with pytest.raises(DynamicalCatalogError):
+            dynamical_catalog.open("nonexistent")
+
     def test_open_unknown_lists_available_sorted(self, populated_catalog):
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(UnknownDatasetError) as excinfo:
             dynamical_catalog.open("nonexistent")
         message = str(excinfo.value)
         # Available datasets are listed sorted in the error message.
@@ -107,24 +121,27 @@ class TestIdentify:
         assert stac._identifier == "second@example.com"
 
     def test_identify_empty_string_disables_identification(self):
-        # Pin current behavior: _user_agent() treats falsy identifiers as
-        # disabled. The follow-up exception PR will widen the type signature.
+        # identify() is typed as ``str | None``; empty string and None both
+        # disable identification. Empty string is normalized to None on
+        # assignment so reads of _identifier are predictable.
         dynamical_catalog.identify("first@example.com")
         dynamical_catalog.identify("")
+        assert stac._identifier is None
         expected = f"dynamical-catalog/{dynamical_catalog.__version__}"
         assert stac._user_agent() == expected
 
     def test_identify_none_disables_identification(self):
-        # Pin current behavior: even though identify() is typed as str, passing
-        # None disables identification because _user_agent() checks falsiness.
         dynamical_catalog.identify("first@example.com")
-        dynamical_catalog.identify(None)  # type: ignore[arg-type]
+        dynamical_catalog.identify(None)
+        assert stac._identifier is None
         expected = f"dynamical-catalog/{dynamical_catalog.__version__}"
         assert stac._user_agent() == expected
 
     def test_identify_non_string_is_coerced(self):
-        # Pin current behavior: f-string interpolation in _user_agent silently
-        # coerces non-strings. Documented as a regression guard, not endorsed.
+        # Pin current behavior: identify() is typed as ``str | None`` and
+        # callers passing other types are misusing the API. f-string
+        # interpolation in _user_agent silently coerces non-strings; this
+        # test documents that as a regression guard, not as an endorsed path.
         dynamical_catalog.identify(42)  # type: ignore[arg-type]
         assert "(42)" in stac._user_agent()
 
@@ -140,6 +157,11 @@ class TestPublicSurface:
     def test_expected_public_names_are_exported(self):
         # Lock in the public API so accidental removals are caught in CI.
         expected = {
+            "CatalogFetchError",
+            "DatasetOpenError",
+            "DynamicalCatalogError",
+            "InvalidCatalogError",
+            "UnknownDatasetError",
             "__version__",
             "clear_cache",
             "get_store",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ from dynamical_catalog.exceptions import (
 
 
 class TestOpen:
-    def test_open_by_id(self, populated_catalog, mocker):
+    def test_open_by_dataset_id(self, populated_catalog, mocker):
         mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
         dynamical_catalog.open("noaa-gfs-forecast")
         mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
@@ -61,7 +61,7 @@ class TestOpen:
 
 
 class TestGetStore:
-    def test_get_store_by_id(self, populated_catalog, mocker):
+    def test_get_store_by_dataset_id(self, populated_catalog, mocker):
         mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
         dynamical_catalog.get_store("noaa-gfs-forecast")
         mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ from dynamical_catalog.exceptions import (
 
 
 class TestOpen:
-    def test_open_by_hyphenated_id(self, populated_catalog, mocker):
+    def test_open_by_id(self, populated_catalog, mocker):
         mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
         dynamical_catalog.open("noaa-gfs-forecast")
         mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
@@ -61,7 +61,7 @@ class TestOpen:
 
 
 class TestGetStore:
-    def test_get_store_by_hyphenated_id(self, populated_catalog, mocker):
+    def test_get_store_by_id(self, populated_catalog, mocker):
         mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
         dynamical_catalog.get_store("noaa-gfs-forecast")
         mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,11 +14,6 @@ class TestOpen:
         dynamical_catalog.open("noaa-gfs-forecast")
         mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
 
-    def test_open_normalizes_underscores(self, populated_catalog, mocker):
-        mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
-        dynamical_catalog.open("noaa_gfs_forecast")
-        mock_open.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
-
     def test_open_passes_kwargs(self, populated_catalog, mocker):
         mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
         dynamical_catalog.open("noaa-gfs-forecast", chunks={"time": 1})
@@ -69,11 +64,6 @@ class TestGetStore:
     def test_get_store_by_hyphenated_id(self, populated_catalog, mocker):
         mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
         dynamical_catalog.get_store("noaa-gfs-forecast")
-        mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
-
-    def test_get_store_normalizes_underscores(self, populated_catalog, mocker):
-        mock_get_store = mocker.patch("dynamical_catalog._open._get_store")
-        dynamical_catalog.get_store("noaa_gfs_forecast")
         mock_get_store.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
 
     def test_get_store_triggers_catalog_fetch_on_cold_cache(

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -175,8 +175,9 @@ class TestGetStoreExceptionWrapping:
             "id": "test",
             "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
         }
-        with pytest.raises(DatasetOpenError, match="Failed to open icechunk"):
+        with pytest.raises(DatasetOpenError, match="Failed to open icechunk") as exc:
             _get_store(data)
+        assert exc.value.dataset_id == "test"
 
     @patch("dynamical_catalog._open.icechunk")
     def test_wrapped_exception_chains_original(self, mock_icechunk):
@@ -190,6 +191,7 @@ class TestGetStoreExceptionWrapping:
         with pytest.raises(DatasetOpenError) as excinfo:
             _get_store(data)
         assert excinfo.value.__cause__ is original
+        assert excinfo.value.dataset_id == "test"
         assert isinstance(excinfo.value, DynamicalCatalogError)
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -6,6 +6,10 @@ import xarray as xr
 import zarr
 
 from dynamical_catalog._open import _get_store, _open_dataset
+from dynamical_catalog.exceptions import (
+    DatasetOpenError,
+    DynamicalCatalogError,
+)
 
 
 class TestGetStoreMocked:
@@ -157,6 +161,36 @@ class TestGetStoreReal:
         ds = _open_dataset(data)
         assert isinstance(ds, xr.Dataset)
         assert "values" in ds.data_vars
+
+
+class TestGetStoreExceptionWrapping:
+    @patch("dynamical_catalog._open.icechunk")
+    def test_icechunk_error_is_wrapped(self, mock_icechunk):
+        # Real subclass so the except-clause in _get_store matches.
+        mock_icechunk.IcechunkError = icechunk.IcechunkError
+        mock_icechunk.Repository.open.side_effect = icechunk.IcechunkError(
+            "bucket not found"
+        )
+        data = {
+            "id": "test",
+            "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
+        }
+        with pytest.raises(DatasetOpenError, match="Failed to open icechunk"):
+            _get_store(data)
+
+    @patch("dynamical_catalog._open.icechunk")
+    def test_wrapped_exception_chains_original(self, mock_icechunk):
+        mock_icechunk.IcechunkError = icechunk.IcechunkError
+        original = icechunk.IcechunkError("bucket not found")
+        mock_icechunk.Repository.open.side_effect = original
+        data = {
+            "id": "test",
+            "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
+        }
+        with pytest.raises(DatasetOpenError) as excinfo:
+            _get_store(data)
+        assert excinfo.value.__cause__ is original
+        assert isinstance(excinfo.value, DynamicalCatalogError)
 
 
 class TestOpenDataset:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -73,7 +73,7 @@ class TestFetchJson:
         )
         with pytest.raises(CatalogFetchError, match="Failed to fetch") as excinfo:
             stac._fetch_json(_CATALOG_URL)
-        assert excinfo.value.url == _CATALOG_URL
+        assert excinfo.value.urls == (_CATALOG_URL,)
         assert excinfo.value.attempts == stac._MAX_ATTEMPTS
         assert isinstance(excinfo.value, DynamicalCatalogError)
 
@@ -530,13 +530,13 @@ class TestLoadCatalog:
             if url == _CATALOG_URL:
                 return MOCK_CATALOG
             raise CatalogFetchError(
-                f"Failed to fetch {url}", url=url, attempts=stac._MAX_ATTEMPTS
+                f"Failed to fetch {url}", urls=(url,), attempts=stac._MAX_ATTEMPTS
             )
 
         mocker.patch.object(stac, "_fetch_json", side_effect=fetch)
         with pytest.raises(CatalogFetchError) as excinfo:
             stac.load_catalog()
-        assert _COLLECTION_URL in str(excinfo.value)
+        assert excinfo.value.urls == (_COLLECTION_URL,)
 
     def test_failing_child_fetch_lists_all_failed_urls(self, mocker):
         catalog = {
@@ -551,15 +551,18 @@ class TestLoadCatalog:
             if url == _CATALOG_URL:
                 return catalog
             raise CatalogFetchError(
-                f"Failed to fetch {url}", url=url, attempts=stac._MAX_ATTEMPTS
+                f"Failed to fetch {url}", urls=(url,), attempts=stac._MAX_ATTEMPTS
             )
 
         mocker.patch.object(stac, "_fetch_json", side_effect=fetch)
         with pytest.raises(CatalogFetchError) as excinfo:
             stac.load_catalog()
-        message = str(excinfo.value)
-        assert "https://stac.dynamical.org/first/collection.json" in message
-        assert "https://stac.dynamical.org/second/collection.json" in message
+        # urls is a tuple of every failed collection URL (order not guaranteed
+        # because as_completed schedules them).
+        assert set(excinfo.value.urls) == {
+            "https://stac.dynamical.org/first/collection.json",
+            "https://stac.dynamical.org/second/collection.json",
+        }
 
 
 class TestClearCache:

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,4 +1,3 @@
-import json
 import urllib.error
 from unittest.mock import MagicMock, call
 
@@ -6,6 +5,11 @@ import pytest
 
 import dynamical_catalog
 import dynamical_catalog._stac as stac
+from dynamical_catalog.exceptions import (
+    CatalogFetchError,
+    DynamicalCatalogError,
+    InvalidCatalogError,
+)
 
 _CATALOG_URL = "https://stac.dynamical.org/catalog.json"
 _COLLECTION_URL = "https://stac.dynamical.org/noaa-gfs-forecast/collection.json"
@@ -60,16 +64,19 @@ def _mock_urlopen_response(mocker, body: bytes):
 
 
 class TestFetchJson:
-    def test_network_error_raises_runtime_error(self, mocker):
+    def test_network_error_raises_catalog_fetch_error(self, mocker):
         mocker.patch.object(
             stac.urllib.request,
             "urlopen",
             side_effect=urllib.error.URLError("connection refused"),
         )
-        with pytest.raises(RuntimeError, match="Failed to fetch"):
+        with pytest.raises(CatalogFetchError, match="Failed to fetch") as excinfo:
             stac._fetch_json(_CATALOG_URL)
+        assert excinfo.value.url == _CATALOG_URL
+        assert excinfo.value.attempts == stac._MAX_ATTEMPTS
+        assert isinstance(excinfo.value, DynamicalCatalogError)
 
-    def test_http_error_raises_runtime_error(self, mocker):
+    def test_http_error_raises_catalog_fetch_error(self, mocker):
         mocker.patch.object(
             stac.urllib.request,
             "urlopen",
@@ -77,7 +84,7 @@ class TestFetchJson:
                 "https://example.com", 403, "Forbidden", {}, None
             ),
         )
-        with pytest.raises(RuntimeError, match="Failed to fetch"):
+        with pytest.raises(CatalogFetchError, match="Failed to fetch"):
             stac._fetch_json("https://example.com")
 
     def test_retries_until_max_attempts_on_persistent_failure(self, mocker):
@@ -87,7 +94,7 @@ class TestFetchJson:
             "urlopen",
             side_effect=urllib.error.URLError("connection refused"),
         )
-        with pytest.raises(RuntimeError):
+        with pytest.raises(CatalogFetchError):
             stac._fetch_json("https://example.com")
         assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
 
@@ -116,7 +123,7 @@ class TestFetchJson:
             "urlopen",
             side_effect=urllib.error.URLError("connection refused"),
         )
-        with pytest.raises(RuntimeError):
+        with pytest.raises(CatalogFetchError):
             stac._fetch_json("https://example.com")
         # Sleeps between attempts but not after the final one.
         expected_sleeps = stac._MAX_ATTEMPTS - 1
@@ -126,13 +133,25 @@ class TestFetchJson:
             == [call(stac._RETRY_BACKOFF_SECONDS)] * expected_sleeps
         )
 
-    def test_malformed_json_response_leaks_decode_error(self, mocker):
-        # PIN: today, json.JSONDecodeError escapes the retry loop unwrapped.
-        # The follow-up exception PR will wrap this as CatalogFetchError and
-        # treat malformed JSON as a retriable error.
+    def test_malformed_json_response_raises_catalog_fetch_error(self, mocker):
+        # Malformed JSON is treated as a retriable failure inside the retry
+        # loop and surfaces as CatalogFetchError after exhaustion.
+        mocker.patch.object(stac.time, "sleep")
         _mock_urlopen_response(mocker, b"not json at all")
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(CatalogFetchError, match="Failed to fetch"):
             stac._fetch_json("https://example.com")
+
+    def test_malformed_json_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(stac.urllib.request, "urlopen")
+        bad = MagicMock()
+        bad.__enter__ = lambda s: s
+        bad.__exit__ = lambda *a: None
+        bad.read.return_value = b"not json"
+        mock_urlopen.return_value = bad
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
 
     def test_uses_configured_timeout(self, mocker):
         mock_urlopen = _mock_urlopen_response(mocker, b"{}")
@@ -185,14 +204,17 @@ class TestParseCollection:
 
     def test_missing_icechunk_asset_raises(self):
         collection = {**MOCK_COLLECTION, "assets": {}}
-        with pytest.raises(ValueError, match="missing an 'icechunk' asset"):
+        with pytest.raises(InvalidCatalogError, match="missing an 'icechunk' asset"):
             stac._parse_collection(collection)
 
-    def test_missing_id_leaks_keyerror(self):
-        # PIN: collection missing 'id' raises bare KeyError. Follow-up will
-        # wrap this as InvalidCatalogError at the parse boundary.
+    def test_missing_id_raises_invalid_catalog_error(self):
         collection = {k: v for k, v in MOCK_COLLECTION.items() if k != "id"}
-        with pytest.raises(KeyError, match="id"):
+        with pytest.raises(InvalidCatalogError, match="missing 'id'"):
+            stac._parse_collection(collection)
+
+    def test_missing_assets_raises_invalid_catalog_error(self):
+        collection = {k: v for k, v in MOCK_COLLECTION.items() if k != "assets"}
+        with pytest.raises(InvalidCatalogError, match="missing 'assets'"):
             stac._parse_collection(collection)
 
     def test_non_s3_href_raises(self):
@@ -207,13 +229,10 @@ class TestParseCollection:
                 }
             },
         }
-        with pytest.raises(ValueError, match="is not an s3:// URL"):
+        with pytest.raises(InvalidCatalogError, match="scheme is not s3"):
             stac._parse_collection(bad)
 
-    def test_empty_prefix_raises_misleading_message(self):
-        # PIN: s3://bucket/ has an empty path after lstrip('/') and raises the
-        # generic "is not an s3:// URL" message. Follow-up will give this
-        # case its own InvalidCatalogError("missing prefix").
+    def test_empty_prefix_raises_missing_prefix(self):
         bad = {
             **MOCK_COLLECTION,
             "assets": {
@@ -225,12 +244,10 @@ class TestParseCollection:
                 }
             },
         }
-        with pytest.raises(ValueError, match="is not an s3:// URL"):
+        with pytest.raises(InvalidCatalogError, match="missing a prefix"):
             stac._parse_collection(bad)
 
-    def test_empty_bucket_raises_misleading_message(self):
-        # PIN: s3:///prefix/ has an empty netloc. Follow-up will give this
-        # case its own InvalidCatalogError("missing bucket").
+    def test_empty_bucket_raises_missing_bucket(self):
         bad = {
             **MOCK_COLLECTION,
             "assets": {
@@ -242,7 +259,7 @@ class TestParseCollection:
                 }
             },
         }
-        with pytest.raises(ValueError, match="is not an s3:// URL"):
+        with pytest.raises(InvalidCatalogError, match="missing a bucket"):
             stac._parse_collection(bad)
 
     def test_missing_region_raises(self):
@@ -254,20 +271,17 @@ class TestParseCollection:
                 }
             },
         }
-        with pytest.raises(ValueError, match="region_name"):
+        with pytest.raises(InvalidCatalogError, match="region_name"):
             stac._parse_collection(bad)
 
     def test_missing_storage_options_raises_via_region_check(self):
-        # PIN: when xarray:storage_options is absent entirely, the chained
-        # .get(..., {}) calls reach the region_name check and raise a
-        # region-shaped error. Follow-up may want a more direct message.
         bad = {
             **MOCK_COLLECTION,
             "assets": {
                 "icechunk": {"href": "s3://bucket/prefix/"},
             },
         }
-        with pytest.raises(ValueError, match="region_name"):
+        with pytest.raises(InvalidCatalogError, match="region_name"):
             stac._parse_collection(bad)
 
 
@@ -315,7 +329,9 @@ class TestParseVirtualChunkContainers:
                 }
             ]
         )
-        with pytest.raises(ValueError, match="url_prefix must be an s3:// string"):
+        with pytest.raises(
+            InvalidCatalogError, match="url_prefix must be an s3:// string"
+        ):
             stac._parse_collection(collection)
 
     def test_non_string_prefix_raises(self):
@@ -327,7 +343,9 @@ class TestParseVirtualChunkContainers:
                 }
             ]
         )
-        with pytest.raises(ValueError, match="url_prefix must be an s3:// string"):
+        with pytest.raises(
+            InvalidCatalogError, match="url_prefix must be an s3:// string"
+        ):
             stac._parse_collection(collection)
 
     def test_non_anonymous_credentials_raises(self):
@@ -343,14 +361,14 @@ class TestParseVirtualChunkContainers:
                 }
             ]
         )
-        with pytest.raises(ValueError, match="anonymous: true"):
+        with pytest.raises(InvalidCatalogError, match="anonymous: true"):
             stac._parse_collection(collection)
 
     def test_missing_credentials_raises(self):
         collection = self._collection_with_containers(
             [{"url_prefix": "s3://somebucket"}]
         )
-        with pytest.raises(ValueError, match="anonymous: true"):
+        with pytest.raises(InvalidCatalogError, match="anonymous: true"):
             stac._parse_collection(collection)
 
     def test_non_s3_credential_type_raises(self):
@@ -362,23 +380,21 @@ class TestParseVirtualChunkContainers:
                 }
             ]
         )
-        with pytest.raises(ValueError, match="anonymous: true"):
+        with pytest.raises(InvalidCatalogError, match="anonymous: true"):
             stac._parse_collection(collection)
 
-    def test_none_value_leaks_typeerror(self):
-        # PIN: today, an explicit None value for the containers key crashes
-        # iteration with TypeError. Follow-up will treat None as empty.
+    def test_none_value_treated_as_empty(self):
+        # An explicit None value for the containers key is treated as empty
+        # (the same as the key being absent).
         collection = self._collection_with_containers(None)
-        with pytest.raises(TypeError):
-            stac._parse_collection(collection)
+        result = stac._parse_collection(collection)
+        assert result["virtual_chunk_containers"] == []
 
-    def test_dict_value_leaks_attributeerror(self):
-        # PIN: a non-list, non-None value (e.g., a dict accidentally written
-        # in the STAC) crashes with AttributeError on the .get('url_prefix')
-        # call. Follow-up will raise InvalidCatalogError with a clearer
-        # message.
+    def test_dict_value_raises_invalid_catalog_error(self):
+        # A non-list, non-None value (e.g., a dict accidentally written in
+        # the STAC) raises InvalidCatalogError with a clear message.
         collection = self._collection_with_containers({"url_prefix": "s3://x"})
-        with pytest.raises(AttributeError):
+        with pytest.raises(InvalidCatalogError, match="must be a list"):
             stac._parse_collection(collection)
 
 
@@ -398,26 +414,20 @@ class TestLoadCatalog:
         result2 = stac.load_catalog()
         assert result2 is result
 
-    def test_missing_links_leaks_keyerror(self, mocker):
-        # PIN: catalog response without a 'links' key raises bare KeyError.
-        # Follow-up will wrap as InvalidCatalogError.
+    def test_missing_links_raises_invalid_catalog_error(self, mocker):
         catalog_without_links = {k: v for k, v in MOCK_CATALOG.items() if k != "links"}
         mocker.patch.object(stac, "_fetch_json", return_value=catalog_without_links)
-        with pytest.raises(KeyError, match="links"):
+        with pytest.raises(InvalidCatalogError, match="missing 'links'"):
             stac.load_catalog()
 
     def test_empty_catalog_returns_empty_dict(self, mocker):
-        # PIN: a catalog with no child links produces an empty datasets dict
-        # silently. Follow-up keeps this as valid behavior; documented here
-        # so a future change doesn't accidentally start raising.
+        # An empty catalog (no child links) is a valid state and returns {}.
         empty_catalog = {**MOCK_CATALOG, "links": []}
         mocker.patch.object(stac, "_fetch_json", return_value=empty_catalog)
         result = stac.load_catalog()
         assert result == {}
 
-    def test_duplicate_ids_silently_overwrite(self, mocker):
-        # PIN: when two child collections share an id, the later one silently
-        # wins. Follow-up will raise InvalidCatalogError listing the dupes.
+    def test_duplicate_ids_raise_invalid_catalog_error(self, mocker):
         catalog = {
             **MOCK_CATALOG,
             "links": [
@@ -452,24 +462,46 @@ class TestLoadCatalog:
         }
         mocker.patch.object(stac, "_fetch_json", side_effect=lambda url: responses[url])
 
-        result = stac.load_catalog()
-        assert list(result.keys()) == ["noaa-gfs-forecast"]
-        # Last write wins.
-        assert result["noaa-gfs-forecast"]["description"] == "second"
+        with pytest.raises(InvalidCatalogError, match="duplicate dataset id"):
+            stac.load_catalog()
 
-    def test_failing_child_fetch_propagates_lazily(self, mocker):
-        # PIN: a child fetch that raises propagates through pool.map's lazy
-        # iterator. Today the user sees the raw RuntimeError from
-        # _fetch_json. Follow-up will gather failures and raise a single
-        # CatalogFetchError listing every failed URL.
+    def test_failing_child_fetch_raises_catalog_fetch_error(self, mocker):
+        # A failing child fetch is gathered into a single CatalogFetchError
+        # listing every failed URL.
         def fetch(url):
             if url == _CATALOG_URL:
                 return MOCK_CATALOG
-            raise RuntimeError(f"Failed to fetch {url}")
+            raise CatalogFetchError(
+                f"Failed to fetch {url}", url=url, attempts=stac._MAX_ATTEMPTS
+            )
 
         mocker.patch.object(stac, "_fetch_json", side_effect=fetch)
-        with pytest.raises(RuntimeError, match="Failed to fetch"):
+        with pytest.raises(CatalogFetchError) as excinfo:
             stac.load_catalog()
+        assert _COLLECTION_URL in str(excinfo.value)
+
+    def test_failing_child_fetch_lists_all_failed_urls(self, mocker):
+        catalog = {
+            **MOCK_CATALOG,
+            "links": [
+                {"rel": "child", "href": "./first/collection.json"},
+                {"rel": "child", "href": "./second/collection.json"},
+            ],
+        }
+
+        def fetch(url):
+            if url == _CATALOG_URL:
+                return catalog
+            raise CatalogFetchError(
+                f"Failed to fetch {url}", url=url, attempts=stac._MAX_ATTEMPTS
+            )
+
+        mocker.patch.object(stac, "_fetch_json", side_effect=fetch)
+        with pytest.raises(CatalogFetchError) as excinfo:
+            stac.load_catalog()
+        message = str(excinfo.value)
+        assert "https://stac.dynamical.org/first/collection.json" in message
+        assert "https://stac.dynamical.org/second/collection.json" in message
 
 
 class TestClearCache:
@@ -510,11 +542,20 @@ class TestIdentifier:
         assert ua == f"dynamical-catalog/{dynamical_catalog.__version__}"
 
     def test_user_agent_omits_parens_when_identifier_is_empty(self):
-        # PIN: empty string is falsy, so _user_agent() already omits the
-        # parens. The follow-up exception PR will widen the type signature
-        # of identify() / set_identifier() to str | None and document this
-        # disable behavior.
-        stac._identifier = ""
+        # set_identifier normalizes "" to None; _user_agent treats falsy
+        # identifiers as disabled.
+        stac.set_identifier("")
         ua = stac._user_agent()
+        assert stac._identifier is None
         assert "(" not in ua
         assert ua == f"dynamical-catalog/{dynamical_catalog.__version__}"
+
+    def test_set_identifier_normalizes_empty_string_to_none(self):
+        stac.set_identifier("acme@example.com")
+        stac.set_identifier("")
+        assert stac._identifier is None
+
+    def test_set_identifier_accepts_none(self):
+        stac.set_identifier("acme@example.com")
+        stac.set_identifier(None)
+        assert stac._identifier is None

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -134,24 +134,20 @@ class TestFetchJson:
         )
 
     def test_malformed_json_response_raises_catalog_fetch_error(self, mocker):
-        # Malformed JSON is treated as a retriable failure inside the retry
-        # loop and surfaces as CatalogFetchError after exhaustion.
-        mocker.patch.object(stac.time, "sleep")
+        # Malformed JSON is wrapped as CatalogFetchError so callers see a
+        # single exception type, but it is NOT retried — a malformed response
+        # body won't change between attempts.
         _mock_urlopen_response(mocker, b"not json at all")
-        with pytest.raises(CatalogFetchError, match="Failed to fetch"):
+        with pytest.raises(CatalogFetchError, match="not valid JSON"):
             stac._fetch_json("https://example.com")
 
-    def test_malformed_json_is_retried(self, mocker):
-        mocker.patch.object(stac.time, "sleep")
-        mock_urlopen = mocker.patch.object(stac.urllib.request, "urlopen")
-        bad = MagicMock()
-        bad.__enter__ = lambda s: s
-        bad.__exit__ = lambda *a: None
-        bad.read.return_value = b"not json"
-        mock_urlopen.return_value = bad
+    def test_malformed_json_is_not_retried(self, mocker):
+        mock_sleep = mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = _mock_urlopen_response(mocker, b"not json")
         with pytest.raises(CatalogFetchError):
             stac._fetch_json("https://example.com")
-        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
+        assert mock_urlopen.call_count == 1
+        mock_sleep.assert_not_called()
 
     def test_uses_configured_timeout(self, mocker):
         mock_urlopen = _mock_urlopen_response(mocker, b"{}")

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,3 +1,4 @@
+import http.client
 import urllib.error
 from unittest.mock import MagicMock, call
 
@@ -76,16 +77,77 @@ class TestFetchJson:
         assert excinfo.value.attempts == stac._MAX_ATTEMPTS
         assert isinstance(excinfo.value, DynamicalCatalogError)
 
-    def test_http_error_raises_catalog_fetch_error(self, mocker):
-        mocker.patch.object(
+    def test_http_4xx_raises_catalog_fetch_error_without_retry(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
             stac.urllib.request,
             "urlopen",
             side_effect=urllib.error.HTTPError(
                 "https://example.com", 403, "Forbidden", {}, None
             ),
         )
-        with pytest.raises(CatalogFetchError, match="Failed to fetch"):
+        with pytest.raises(CatalogFetchError, match="HTTP 403"):
             stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == 1
+
+    def test_http_429_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
+            stac.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.HTTPError(
+                "https://example.com", 429, "Too Many Requests", {}, None
+            ),
+        )
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
+
+    def test_http_5xx_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
+            stac.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.HTTPError(
+                "https://example.com", 503, "Service Unavailable", {}, None
+            ),
+        )
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
+
+    def test_timeout_error_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
+            stac.urllib.request,
+            "urlopen",
+            side_effect=TimeoutError("read timed out"),
+        )
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
+
+    def test_remote_disconnected_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
+            stac.urllib.request,
+            "urlopen",
+            side_effect=http.client.RemoteDisconnected("server closed connection"),
+        )
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
+
+    def test_incomplete_read_is_retried(self, mocker):
+        mocker.patch.object(stac.time, "sleep")
+        mock_urlopen = mocker.patch.object(
+            stac.urllib.request,
+            "urlopen",
+            side_effect=http.client.IncompleteRead(b"partial", expected=42),
+        )
+        with pytest.raises(CatalogFetchError):
+            stac._fetch_json("https://example.com")
+        assert mock_urlopen.call_count == stac._MAX_ATTEMPTS
 
     def test_retries_until_max_attempts_on_persistent_failure(self, mocker):
         mocker.patch.object(stac.time, "sleep")

--- a/tests/test_virtual_open.py
+++ b/tests/test_virtual_open.py
@@ -165,5 +165,7 @@ class TestVirtualOpen:
             side_effect=_mock_stac_fetch(with_virtual_containers=False),
         ):
             ds = dynamical_catalog.open(_DATASET_ID)
+            # Lazy reads are out of scope for the DatasetOpenError wrap, so
+            # the underlying icechunk error still surfaces here.
             with pytest.raises(icechunk.IcechunkError, match="virtual chunk"):
                 _ = ds["grib_bytes"].values

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ wheels = [
 
 [[package]]
 name = "dynamical-catalog"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "icechunk" },


### PR DESCRIPTION
## Summary

We previously didn't document possible exceptions that this library could raise. This PR explicitly enumerates failure cases and documents specific exceptions for each. This PR does not modify happy path usage and it's user impact is expected to be minimal.

Bumps to **0.6.0**.

Implements [#8](https://github.com/dynamical-org/dynamical-catalog/issues/8): library-owned exception hierarchy, typed raises across the package, refined retry policy, and expanded public-API docstrings. 

## Exception hierarchy

New `dynamical_catalog/exceptions.py`, re-exported from the package root:

- `DynamicalCatalogError` — base class for everything we raise.
- `UnknownDatasetError` — also subclasses `ValueError` so existing `except ValueError` callers keep working.
- `CatalogFetchError(message, *, urls: tuple[str, ...], attempts: int)` — network / HTTP / malformed-JSON failures fetching the STAC catalog. `urls` stores `(url,)` for single-URL failures and every failed URL for aggregated child fetches.
- `InvalidCatalogError` — catalog response was reachable but contents failed validation.
- `DatasetOpenError(message, *, dataset_id: str | None = None)` — failure opening the icechunk repo or zarr/xarray store; carries the dataset id when known.

Every wrapped error chains the underlying exception via `raise ... from original`, so callers who want sophisticated retry logic can introspect `__cause__`.

## STAC catalog behavior

- All raises in `_stac.py` use the typed exceptions above.
- `s3://` href validation produces specific "missing bucket" / "missing prefix" / "scheme is not s3" `InvalidCatalogError` messages.
- Missing `links` / `id` / `assets` keys raise `InvalidCatalogError` rather than bare `KeyError`.
- `icechunk:virtual_chunk_containers: null` is treated as empty; non-list non-`None` values raise `InvalidCatalogError`.
- Duplicate dataset ids across child collections raise `InvalidCatalogError`.
- Failing child fetches are drained via `as_completed` and aggregated into a single `CatalogFetchError` listing every failed URL.

## Retry policy in `_fetch_json`

- Retries on `URLError`, `TimeoutError`, `http.client.RemoteDisconnected`, `http.client.IncompleteRead`, HTTP 5xx, and HTTP 429 — each up to `_MAX_ATTEMPTS` with backoff.
- Fails fast on HTTP 4xx other than 429 and on `JSONDecodeError` — these won't change between attempts.
- After exhaustion, surfaces a single `CatalogFetchError`.

## Dataset open behavior

`_open.py` wraps `icechunk.IcechunkError` from `Repository.open` and any errors from `xr.open_zarr` as `DatasetOpenError(dataset_id=...)`. Lazy errors raised when the caller later reads data from the returned `Dataset` are intentionally not wrapped.

## Public API

- `identify(identifier: str | None)` — widened from `str`. Empty string is normalized to `None` in `set_identifier`. Docstring is a two-sentence user-facing contract; User-Agent format details are out (implementation detail).
- Full Args / Returns / Raises docstrings on `clear_cache`, `get_store`, `identify`, `list`, `open`.
- Exception classes are part of `__all__`.

## Underscore dataset ids

A previously-released version documented underscore-form ids (`noaa_gfs_forecast`). The hyphenated form is canonical going forward; the underscore form is preserved behind a `DeprecationWarning` that:

- Fires only when the underscore id resolves to a real dataset (a typo with underscores still surfaces as `UnknownDatasetError`, no misleading deprecation notice).
- Announces removal in 1.0 and points to the canonical hyphenated id.

The docstrings do not advertise underscores — this is a deprecated migration path, not a documented feature.

## Repo guidance

Adds `CLAUDE.md` with the pre-commit checklist (`ruff format`, `ruff check`, `mypy src`, `pytest`).

## Test plan

- [x] Tests assert the new exception types, attributes (`urls`, `attempts`, `dataset_id`), and `isinstance(err, DynamicalCatalogError)` chaining.
- [x] Retry semantics pinned: 4xx-not-429 and malformed JSON fail on first attempt; 429 / 5xx / `TimeoutError` / `RemoteDisconnected` / `IncompleteRead` / `URLError` retry up to `_MAX_ATTEMPTS`.
- [x] Underscore deprecation pinned: resolved underscore id emits `DeprecationWarning`; unresolved underscore id raises `UnknownDatasetError` with no warning.
- [x] `ruff format` / `ruff check` / `mypy src` / `pytest` clean locally.
- [x] `pytest -m slow` (network-bound integration tests).
