### PR TITLE
Warn on non-str identifiers in identify(); add cache and exception tests

### DIFF
--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -31,8 +31,10 @@ def identify(identifier: str | None) -> None:
     """
     if identifier is not None and not isinstance(identifier, str):
         warnings.warn(
-            "Passing non-str identifiers to identify() is deprecated and will be removed in 1.0; "
-            "pass str or None.",
+            (
+                "Passing non-str identifiers to identify() is deprecated and will be "
+                "removed in 1.0; pass str or None."
+            ),
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -25,12 +25,17 @@ __version__ = version("dynamical-catalog")
 def identify(identifier: str | None) -> None:
     """Set a user identifier to help dynamical.org improve the catalog.
 
-    Passing an empty string or ``None`` disables identification.
-
     Args:
         identifier: Email or company name (e.g. ``"you@example.com"``), or
             ``None`` / ``""`` to disable identification.
     """
+    if identifier is not None and not isinstance(identifier, str):
+        warnings.warn(
+            "Passing non-str identifiers to identify() is deprecated and will be removed in 1.0; "
+            "pass str or None.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     set_identifier(identifier)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,13 +155,45 @@ class TestIdentify:
         expected = f"dynamical-catalog/{dynamical_catalog.__version__}"
         assert stac._user_agent() == expected
 
-    def test_identify_non_string_is_coerced(self):
-        # Pin current behavior: identify() is typed as ``str | None`` and
-        # callers passing other types are misusing the API. f-string
-        # interpolation in _user_agent silently coerces non-strings; this
-        # test documents that as a regression guard, not as an endorsed path.
-        dynamical_catalog.identify(42)  # type: ignore[arg-type]
+    def test_identify_non_string_warns_deprecated_behavior(self):
+        with pytest.warns(DeprecationWarning, match="deprecated and will be removed in 1.0"):
+            dynamical_catalog.identify(42)  # type: ignore[arg-type]
         assert "(42)" in stac._user_agent()
+
+
+class TestClearCache:
+    def test_clear_cache_resets_cached_catalog(self, sample_datasets, mocker):
+        # Prime cache, then ensure clear_cache forces a refetch path.
+        stac._datasets = sample_datasets
+        dynamical_catalog.clear_cache()
+
+        mock_load = mocker.patch(
+            "dynamical_catalog.load_catalog", return_value=sample_datasets
+        )
+        mock_open = mocker.patch("dynamical_catalog._open._open_dataset")
+
+        dynamical_catalog.open("noaa-gfs-forecast")
+
+        mock_load.assert_called_once()
+        mock_open.assert_called_once_with(sample_datasets["noaa-gfs-forecast"])
+
+    def test_clear_cache_returns_none(self):
+        assert dynamical_catalog.clear_cache() is None
+
+
+class TestPublicExceptions:
+    def test_catalog_fetch_error_exposes_urls_and_attempts(self):
+        err = dynamical_catalog.CatalogFetchError(
+            "boom", urls=("https://example.com",), attempts=3
+        )
+
+        assert err.urls == ("https://example.com",)
+        assert err.attempts == 3
+
+    def test_dataset_open_error_exposes_dataset_id(self):
+        err = dynamical_catalog.DatasetOpenError("boom", dataset_id="abc")
+
+        assert err.dataset_id == "abc"
 
 
 class TestPublicSurface:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,7 +156,10 @@ class TestIdentify:
         assert stac._user_agent() == expected
 
     def test_identify_non_string_warns_deprecated_behavior(self):
-        with pytest.warns(DeprecationWarning, match="deprecated and will be removed in 1.0"):
+        with pytest.warns(
+            DeprecationWarning,
+            match="deprecated and will be removed in 1.0",
+        ):
             dynamical_catalog.identify(42)  # type: ignore[arg-type]
         assert "(42)" in stac._user_agent()
 


### PR DESCRIPTION
### Motivation
- The `identify()` API is typed as `str | None` but does not run time check this. 
- Improve coverage around cache invalidation and public exception payloads to prevent regressions.

### Description
- Emit a `DeprecationWarning` in `identify()` when `identifier` is not `None` and not a `str`, with a message noting removal in 1.0. 
- Update `tests/test_api.py` to expect a `DeprecationWarning` for non-string identifiers and replace the previous coercion-based assertion. 
- Add `TestClearCache` to verify `clear_cache()` forces a refetch path and returns `None`, and add `TestPublicExceptions` to assert `CatalogFetchError` and `DatasetOpenError` expose their attributes. 
- Preserve existing empty-string/`None` normalization and `set_identifier` behavior.

### Testing
- Ran `pytest tests/test_api.py` which executed the updated unit tests and they passed. 
- Ran the full `pytest` suite and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bced4894832895c9b55364577964)