### PR TITLE
Release v0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynamical-catalog"
-version = "0.6.0"
+version = "0.7.0"
 description = "Load dynamical.org weather datasets in one line"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the zarr~=3.2 / icechunk / gribberish~=1.5.0 dependency update (#15, reformatters#724).

Bumping via PR since `main` requires PRs + passing checks — the `Release & Publish` workflow's direct push to `main` is currently blocked by that ruleset for the `github-actions[bot]` actor (not in the bypass list, and the built-in Actions identity can't be added as a ruleset bypass actor). Tagging/GitHub release/PyPI publish for `v0.7.0` will be done manually against this PR's merge commit once merged.