### PR TITLE
Add public get_repository() for icechunk repo access

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,23 @@
+name: Staging integration
+
+# Live staging-catalog integration tests (`-m staging`). Staging serves whatever
+# is mid-deploy, so these are expected to go red on catalog drift. This check is
+# intentionally NOT a required status check: it surfaces drift on every PR/push
+# without blocking merge. Production coverage that DOES gate merge runs in the
+# Test workflow (`-m "not staging"`, which still includes tests/test_integration.py).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/ -v -m staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,6 +11,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
-      - run: pytest tests/ -v -m "slow or not slow"
+      - run: pytest tests/ -v -m "not staging"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ds = dynamical_catalog.open("noaa-gfs-forecast")
 ds = dynamical_catalog.open("noaa-gfs-forecast", chunks=None)
 
 # Datasets with vertical profiles expose them as groups (e.g. pressure_level)
-ds = dynamical_catalog.open("noaa-hrrr-forecast-48-hour-spatial", group="pressure_level")
+ds = dynamical_catalog.open("noaa-hrrr-forecast-48-hour-virtual", group="pressure_level")
 
 # Get the underlying Zarr store if you want even more control
 store = dynamical_catalog.get_store("noaa-gfs-forecast")

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ ds = dynamical_catalog.open("noaa-hrrr-forecast-48-hour-spatial", group="pressur
 store = dynamical_catalog.get_store("noaa-gfs-forecast")
 ds = xr.open_zarr(store)
 
+# Get the icechunk repository itself to access its commit history / snapshots
+repo = dynamical_catalog.get_repository("noaa-gfs-forecast")
+for snapshot in repo.ancestry(branch="main"):
+    print(snapshot.written_at, snapshot.message)
+
 # List all available datasets
 dynamical_catalog.list()
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynamical-catalog"
-version = "0.7.0"
+version = "0.8.0"
 description = "Load dynamical.org weather datasets in one line"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ packages = ["src/dynamical_catalog"]
 addopts = "-m 'not slow'"
 markers = [
     "slow: marks tests as slow (hit real network, run with pytest -m slow)",
+    "staging: hits the live staging STAC catalog; excluded from per-PR CI and run in the scheduled Integration workflow (also marked slow)",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ packages = ["src/dynamical_catalog"]
 addopts = "-m 'not slow'"
 markers = [
     "slow: marks tests as slow (hit real network, run with pytest -m slow)",
-    "staging: hits the live staging STAC catalog; excluded from per-PR CI and run in the scheduled Integration workflow (also marked slow)",
+    "staging: hits the live staging STAC catalog; runs in the non-blocking Staging integration workflow, kept out of the merge-gating test job (also marked slow)",
 ]
 
 [tool.ruff]

--- a/src/dynamical_catalog/__init__.py
+++ b/src/dynamical_catalog/__init__.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import icechunk
     import xarray as xr
     from zarr.abc.store import Store
 
@@ -63,6 +64,35 @@ def get_store(dataset_id: str) -> Store:
     from dynamical_catalog._open import _get_store
 
     return _get_store(_resolve(dataset_id))
+
+
+def get_repository(dataset_id: str) -> icechunk.Repository:
+    """Open a dynamical.org dataset's icechunk repository read-only and anonymously.
+
+    Lower-level than :func:`get_store` and :func:`open`, which collapse the
+    repository to the ``main`` tip. Returning the repository gives the caller its
+    full history — ``ancestry()`` for commit metadata and per-snapshot
+    ``readonly_session()`` — as needed for e.g. monitoring dataset publication.
+    Virtual chunk containers are authorized so reads resolve their source chunks.
+
+    On the first call (per process) this fetches the STAC catalog from
+    dynamical.org; subsequent calls reuse the in-process cache.
+
+    Args:
+        dataset_id: Dataset identifier (e.g. ``"noaa-gfs-forecast"``).
+
+    Returns:
+        A read-only :class:`icechunk.Repository`.
+
+    Raises:
+        UnknownDatasetError: ``dataset_id`` is not in the catalog.
+        CatalogFetchError: Fetching the STAC catalog failed.
+        InvalidCatalogError: The catalog response was reachable but malformed.
+        DatasetOpenError: Opening the icechunk repository failed.
+    """
+    from dynamical_catalog._open import _get_repository
+
+    return _get_repository(_resolve(dataset_id))
 
 
 def open(dataset_id: str, **kwargs: Any) -> xr.Dataset:
@@ -138,6 +168,7 @@ __all__ = [
     "UnknownDatasetError",
     "__version__",
     "clear_cache",
+    "get_repository",
     "get_store",
     "identify",
     "list",

--- a/src/dynamical_catalog/_open.py
+++ b/src/dynamical_catalog/_open.py
@@ -43,7 +43,15 @@ def _get_repository(dataset_data: dict[str, Any]) -> icechunk.Repository:
 
 
 def _get_store(dataset_data: dict[str, Any]) -> Store:
-    return _get_repository(dataset_data).readonly_session("main").store
+    repo = _get_repository(dataset_data)
+    dataset_id = dataset_data.get("id")
+    try:
+        return repo.readonly_session("main").store
+    except icechunk.IcechunkError as e:
+        raise DatasetOpenError(
+            f"Failed to open icechunk repository for dataset {dataset_id!r}: {e}",
+            dataset_id=dataset_id,
+        ) from e
 
 
 def _open_dataset(dataset_data: dict[str, Any], **kwargs: Any) -> xr.Dataset:

--- a/src/dynamical_catalog/_open.py
+++ b/src/dynamical_catalog/_open.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from zarr.abc.store import Store
 
 
-def _get_store(dataset_data: dict[str, Any]) -> Store:
+def _get_repository(dataset_data: dict[str, Any]) -> icechunk.Repository:
     config = dataset_data["icechunk"]
     storage = icechunk.s3_storage(
         bucket=config["bucket"],
@@ -19,6 +19,9 @@ def _get_store(dataset_data: dict[str, Any]) -> Store:
         region=config["region"],
         anonymous=True,
     )
+    # A virtual dataset's chunks are byte-range references into public source
+    # buckets; icechunk raises unless each such container is authorized at open
+    # time (the container registration itself is already persisted on the repo).
     prefixes = dataset_data.get("virtual_chunk_containers") or []
     authorize = (
         icechunk.containers_credentials(
@@ -29,16 +32,18 @@ def _get_store(dataset_data: dict[str, Any]) -> Store:
     )
     dataset_id = dataset_data.get("id")
     try:
-        repo = icechunk.Repository.open(
+        return icechunk.Repository.open(
             storage, authorize_virtual_chunk_access=authorize
         )
-        session = repo.readonly_session("main")
-        return session.store
     except icechunk.IcechunkError as e:
         raise DatasetOpenError(
             f"Failed to open icechunk repository for dataset {dataset_id!r}: {e}",
             dataset_id=dataset_id,
         ) from e
+
+
+def _get_store(dataset_data: dict[str, Any]) -> Store:
+    return _get_repository(dataset_data).readonly_session("main").store
 
 
 def _open_dataset(dataset_data: dict[str, Any], **kwargs: Any) -> xr.Dataset:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,35 @@ class TestGetStore:
         mock_get_store.assert_called_once_with(sample_datasets["noaa-gfs-forecast"])
 
 
+class TestGetRepository:
+    def test_get_repository_by_dataset_id(self, populated_catalog, mocker):
+        mock_get_repo = mocker.patch("dynamical_catalog._open._get_repository")
+        dynamical_catalog.get_repository("noaa-gfs-forecast")
+        mock_get_repo.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
+
+    def test_get_repository_underscore_id_resolves_with_deprecation_warning(
+        self, populated_catalog, mocker
+    ):
+        mock_get_repo = mocker.patch("dynamical_catalog._open._get_repository")
+        with pytest.warns(DeprecationWarning, match="Underscores in dataset ids"):
+            dynamical_catalog.get_repository("noaa_gfs_forecast")
+        mock_get_repo.assert_called_once_with(populated_catalog["noaa-gfs-forecast"])
+
+    def test_get_repository_triggers_catalog_fetch_on_cold_cache(
+        self, sample_datasets, mocker
+    ):
+        stac._datasets = None
+        mock_load = mocker.patch(
+            "dynamical_catalog.load_catalog", return_value=sample_datasets
+        )
+        mock_get_repo = mocker.patch("dynamical_catalog._open._get_repository")
+
+        dynamical_catalog.get_repository("noaa-gfs-forecast")
+
+        mock_load.assert_called_once()
+        mock_get_repo.assert_called_once_with(sample_datasets["noaa-gfs-forecast"])
+
+
 class TestList:
     def test_list_returns_sorted_ids(self, populated_catalog):
         ids = dynamical_catalog.list()
@@ -217,6 +246,7 @@ class TestPublicSurface:
             "UnknownDatasetError",
             "__version__",
             "clear_cache",
+            "get_repository",
             "get_store",
             "identify",
             "list",

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -241,6 +241,23 @@ class TestGetStoreExceptionWrapping:
         assert exc.value.dataset_id == "test"
 
     @patch("dynamical_catalog._open.icechunk")
+    def test_readonly_session_error_is_wrapped(self, mock_icechunk):
+        # An IcechunkError raised while opening the "main" session (not by
+        # Repository.open) is still surfaced as DatasetOpenError, matching the
+        # pre-refactor behavior where open + session + store shared one try block.
+        mock_icechunk.IcechunkError = icechunk.IcechunkError
+        mock_icechunk.Repository.open.return_value.readonly_session.side_effect = (
+            icechunk.IcechunkError("no main branch")
+        )
+        data = {
+            "id": "test",
+            "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
+        }
+        with pytest.raises(DatasetOpenError, match="Failed to open icechunk") as exc:
+            _get_store(data)
+        assert exc.value.dataset_id == "test"
+
+    @patch("dynamical_catalog._open.icechunk")
     def test_wrapped_exception_chains_original(self, mock_icechunk):
         mock_icechunk.IcechunkError = icechunk.IcechunkError
         original = icechunk.IcechunkError("bucket not found")

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 import zarr
 
-from dynamical_catalog._open import _get_store, _open_dataset
+from dynamical_catalog._open import _get_repository, _get_store, _open_dataset
 from dynamical_catalog.exceptions import (
     DatasetOpenError,
     DynamicalCatalogError,
@@ -104,6 +104,67 @@ class TestGetStoreMocked:
             mock_icechunk.s3_storage.return_value,
             authorize_virtual_chunk_access=None,
         )
+
+
+class TestGetRepository:
+    @patch("dynamical_catalog._open.icechunk")
+    def test_returns_opened_repository(self, mock_icechunk):
+        # get_repository hands back the Repository itself (history intact), not a
+        # tip store — that's the whole reason it exists alongside _get_store.
+        data = {
+            "id": "test",
+            "icechunk": {
+                "bucket": "dynamical-test",
+                "prefix": "test/v0.1.0.icechunk/",
+                "region": "us-west-2",
+            },
+        }
+
+        repo = _get_repository(data)
+
+        mock_icechunk.s3_storage.assert_called_once_with(
+            bucket="dynamical-test",
+            prefix="test/v0.1.0.icechunk/",
+            region="us-west-2",
+            anonymous=True,
+        )
+        mock_icechunk.Repository.open.assert_called_once_with(
+            mock_icechunk.s3_storage.return_value,
+            authorize_virtual_chunk_access=None,
+        )
+        assert repo is mock_icechunk.Repository.open.return_value
+        mock_icechunk.Repository.open.return_value.readonly_session.assert_not_called()
+
+    @patch("dynamical_catalog._open.icechunk")
+    def test_authorizes_virtual_chunk_containers(self, mock_icechunk):
+        data = {
+            "id": "test",
+            "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
+            "virtual_chunk_containers": ["s3://noaa-hrrr-bdp-pds"],
+        }
+        anon_cred = mock_icechunk.s3_anonymous_credentials.return_value
+
+        _get_repository(data)
+
+        mock_icechunk.containers_credentials.assert_called_once_with(
+            {"s3://noaa-hrrr-bdp-pds": anon_cred}
+        )
+        mock_icechunk.Repository.open.assert_called_once_with(
+            mock_icechunk.s3_storage.return_value,
+            authorize_virtual_chunk_access=mock_icechunk.containers_credentials.return_value,
+        )
+
+    @patch("dynamical_catalog._open.icechunk")
+    def test_icechunk_error_is_wrapped(self, mock_icechunk):
+        mock_icechunk.IcechunkError = icechunk.IcechunkError
+        mock_icechunk.Repository.open.side_effect = icechunk.IcechunkError("boom")
+        data = {
+            "id": "test",
+            "icechunk": {"bucket": "b", "prefix": "p/", "region": "us-west-2"},
+        }
+        with pytest.raises(DatasetOpenError, match="Failed to open icechunk") as exc:
+            _get_repository(data)
+        assert exc.value.dataset_id == "test"
 
 
 class TestGetStoreReal:

--- a/tests/test_staging_integration.py
+++ b/tests/test_staging_integration.py
@@ -11,7 +11,13 @@ coverage there. These tests point the public API at staging via
 GRIB decode on read is covered deterministically by test_virtual_open.py;
 these tests open lazily, matching test_integration.py.
 
-Run with: pytest -m slow
+Marked ``staging`` (as well as ``slow``): they depend on whatever the live
+staging catalog happens to be serving, so they are excluded from the per-PR
+test job (``-m "not staging"``) and run in the scheduled Integration workflow
+instead. That keeps staging catalog drift from turning unrelated PRs red while
+still surfacing it daily.
+
+Run with: pytest -m staging
 """
 
 import icechunk
@@ -21,10 +27,10 @@ import xarray as xr
 import dynamical_catalog
 from dynamical_catalog._stac import CATALOG_URL_ENV_VAR, STAGING_STAC_CATALOG_URL
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.slow, pytest.mark.staging]
 
 # Multi-group virtual dataset published to staging; carries both vertical groups.
-_GROUPED_DATASET = "noaa-hrrr-forecast-48-hour-spatial"
+_GROUPED_DATASET = "noaa-hrrr-forecast-48-hour-virtual"
 _VERTICAL_GROUPS = ("pressure_level", "model_level")
 
 

--- a/tests/test_staging_integration.py
+++ b/tests/test_staging_integration.py
@@ -12,10 +12,11 @@ GRIB decode on read is covered deterministically by test_virtual_open.py;
 these tests open lazily, matching test_integration.py.
 
 Marked ``staging`` (as well as ``slow``): they depend on whatever the live
-staging catalog happens to be serving, so they are excluded from the per-PR
-test job (``-m "not staging"``) and run in the scheduled Integration workflow
-instead. That keeps staging catalog drift from turning unrelated PRs red while
-still surfacing it daily.
+staging catalog happens to be serving. The merge-gating ``test`` job excludes
+them (``-m "not staging"``); they run instead in the dedicated ``Staging
+integration`` workflow (``-m staging``), which surfaces staging drift on every
+PR but is intentionally not a required check, so it never blocks merge.
+Production coverage that does gate merge lives in test_integration.py.
 
 Run with: pytest -m staging
 """

--- a/tests/test_staging_integration.py
+++ b/tests/test_staging_integration.py
@@ -21,7 +21,6 @@ Production coverage that does gate merge lives in test_integration.py.
 Run with: pytest -m staging
 """
 
-import icechunk
 import pytest
 import xarray as xr
 
@@ -65,17 +64,10 @@ class TestVerticalGroups:
         assert group in ds.dims, f"{group} group is missing its {group!r} dimension"
         assert len(ds.data_vars) > 0, f"{group} group has no data variables"
 
-    # This dataset's chunks are virtual refs into a public source bucket, so a
-    # read only resolves if the staging collection advertises the source via
-    # icechunk:virtual_chunk_containers. That emission is added by dynamical-stac
-    # PR #38; until staging is redeployed with it, the read raises. strict=True
-    # flips this to a failure once the read succeeds, prompting removal of the
-    # marker and confirming the fix reached staging.
-    @pytest.mark.xfail(
-        raises=icechunk.IcechunkError,
-        strict=True,
-        reason="staging STAC does not yet advertise icechunk:virtual_chunk_containers",
-    )
+    # This dataset's chunks are virtual refs into a public source bucket; the
+    # read resolves because the staging collection advertises the source via
+    # icechunk:virtual_chunk_containers (dynamical-stac PR #38) and open()
+    # authorizes those containers at open time.
     def test_read_vertical_group_chunk(self):
         ds = dynamical_catalog.open(_GROUPED_DATASET, group="pressure_level")
         da = ds["geopotential_height"]

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ wheels = [
 
 [[package]]
 name = "dynamical-catalog"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "gribberish" },


### PR DESCRIPTION
## Summary

Adds a public `dynamical_catalog.get_repository(dataset_id) -> icechunk.Repository`, extracted from the existing `_get_store` so the storage construction and — critically — the **virtual-chunk-container authorization** live in one shared place.

`get_store()` and `open()` both collapse a dataset to its `main` tip (a zarr `Store` / xarray `Dataset`). Callers that need the repository's **commit history** (`ancestry()`) or **per-snapshot** `readonly_session()` had no supported entry point and were forced to re-implement repo opening themselves — including the anonymous virtual-chunk-container authorization that a virtual dataset (e.g. `noaa-hrrr-forecast-48-hour-virtual`, whose chunks reference `s3://noaa-hrrr-bdp-pds/`) requires at open time. Omitting that authorization is exactly the failure that produced a high-volume `IcechunkError` in the publication monitor (wxopticon). Centralizing it here means the concern is defined once and stays correct as new data products are released.

This PR also reorganizes the STAC integration tests so that transient live-**staging** catalog drift no longer blocks unrelated PRs, and bumps the version to 0.8.0.

## Changes

### `get_repository()` API
- `_open.py`: extract `_get_repository(dataset_data) -> icechunk.Repository`; `_get_store` now returns `_get_repository(...).readonly_session("main").store` and re-wraps an `IcechunkError` from the session/store step in `DatasetOpenError` — so the externally observable behavior of `_get_store` / `get_store` / `open` is unchanged.
- `__init__.py`: add public `get_repository()` (mirrors `get_store`'s id-resolution, cold-cache fetch, and deprecation-warning handling); add to `__all__`.
- Tests: `TestGetRepository` in `test_open.py` (returns the Repository, not a tip store; authorizes virtual chunk containers; wraps `IcechunkError`) and in `test_api.py` (id resolution, underscore deprecation, cold-cache fetch); a `_get_store` session-error wrapping test; lock `get_repository` into the exported-surface test.
- `README.md`: document `get_repository()` with an `ancestry()` example.

### CI: separate prod and staging STAC integration tests
- Staging integration tests are marked `staging`. The merge-gating `test` job runs `-m "not staging"`, which keeps unit, deterministic-slow (`test_virtual_open.py`), and **production** STAC integration (`test_integration.py`) coverage as a required gate.
- A dedicated **`Staging integration`** workflow (`.github/workflows/staging.yml`) runs `-m staging` on every PR/push. It is intentionally **not** a required status check, so live-staging drift is surfaced without blocking merge.
- Re-point the staging grouped dataset from the renamed `noaa-hrrr-forecast-48-hour-spatial` to `noaa-hrrr-forecast-48-hour-virtual` (README + test), and drop the now-obsolete `xfail` on the virtual-chunk read now that staging advertises `icechunk:virtual_chunk_containers`.
- `staging.yml` sets an explicit `permissions: contents: read`.

### Version
- 0.7.0 → 0.8.0 (additive).

## Verification

- `ruff format` / `ruff check` / `mypy src` clean.
- Required CI green: `lint`, `test (3.12)`, `test (3.13)`, `test (3.14)`.
- The `Staging integration` check runs `-m staging` against live staging: both vertical groups (`pressure_level` / `model_level`) open and the virtual-chunk read resolves.

## Follow-up

wxopticon will consume this in place of its own `open_repo`/`resolve_store` (dynamical-org/wxopticon#78). That makes `dynamical-catalog` a runtime dependency of wxopticon, which currently keeps its icechunk reader xarray-free; `dynamical-catalog` requires `xarray`, so it would enter wxopticon's transitive install. If keeping lightweight consumers xarray-free is desirable, a natural follow-up is to move `xarray` to an optional extra (needed only by `open()`) — deferred here because it's a breaking change to this published library's headline one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)