### PR TITLE
Add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
Adds a Dependabot version-updates config (weekly, all updates grouped into one PR to reduce noise). Complements the existing Dependabot **security** updates. Part of the security-questionnaire remediation pass — see meta/security/security-questionnaire-reference.md (§K3).