### PR TITLE
Remove extraneous comments per code-style standard

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,7 @@ class TestOpen:
 
     def test_open_unknown_is_value_error_for_compat(self, populated_catalog):
         # UnknownDatasetError multi-inherits from ValueError so callers that
-        # caught ValueError before the typed-exception migration keep working.
+        # catch ValueError keep working.
         with pytest.raises(ValueError, match="Unknown dataset"):
             dynamical_catalog.open("nonexistent")
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -243,8 +243,7 @@ class TestGetStoreExceptionWrapping:
     @patch("dynamical_catalog._open.icechunk")
     def test_readonly_session_error_is_wrapped(self, mock_icechunk):
         # An IcechunkError raised while opening the "main" session (not by
-        # Repository.open) is still surfaced as DatasetOpenError, matching the
-        # pre-refactor behavior where open + session + store shared one try block.
+        # Repository.open) is still surfaced as DatasetOpenError.
         mock_icechunk.IcechunkError = icechunk.IcechunkError
         mock_icechunk.Repository.open.return_value.readonly_session.side_effect = (
             icechunk.IcechunkError("no main branch")

--- a/tests/test_staging_integration.py
+++ b/tests/test_staging_integration.py
@@ -66,8 +66,8 @@ class TestVerticalGroups:
 
     # This dataset's chunks are virtual refs into a public source bucket; the
     # read resolves because the staging collection advertises the source via
-    # icechunk:virtual_chunk_containers (dynamical-stac PR #38) and open()
-    # authorizes those containers at open time.
+    # icechunk:virtual_chunk_containers and open() authorizes those containers
+    # at open time.
     def test_read_vertical_group_chunk(self):
         ds = dynamical_catalog.open(_GROUPED_DATASET, group="pressure_level")
         da = ds["geopotential_height"]


### PR DESCRIPTION
Comment-hygiene pass over Python source and tests. The repo is already very well maintained, so only three test comments carried genuinely extraneous change-narrative / PR references; each was trimmed to its timeless factual core (no behavior change).

- `tests/test_api.py`: dropped "before the typed-exception migration" from the ValueError-compat note.
- `tests/test_open.py`: dropped the "matching the pre-refactor behavior where open + session + store shared one try block" clause.
- `tests/test_staging_integration.py`: removed the "(dynamical-stac PR #38)" reference.

Checks: `ruff format` (unchanged), `ruff check` (passed), `mypy src` (passed), `pytest` (94 passed, 15 slow/staging deselected).